### PR TITLE
Redact OpenAI shim key placeholder

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -10,7 +10,7 @@
  *
  * Environment variables:
  *   CLAUDE_CODE_USE_OPENAI=1          — enable this provider
- *   OPENAI_API_KEY=sk-...             — API key (optional for local models)
+ *   OPENAI_API_KEY=<openai-api-key>   — API key (optional for local models)
  *   OPENAI_BASE_URL=http://...        — base URL (default: https://api.openai.com/v1)
  *   OPENAI_MODEL=gpt-4o              — default model override
  *   CODEX_API_KEY / ~/.codex/auth.json — Codex auth for codexplan/codexspark


### PR DESCRIPTION
## Summary
- Replace the remaining OPENAI_API_KEY=sk-... documentation example in openaiShim.ts with an angle-bracket placeholder.
- Keeps public default-branch scans quieter while preserving setup meaning.

## Verification
- focused secret-shaped placeholder grep over .env.example/docs/openaiShim
- bun run verify:privacy
- bun run typecheck --pretty false
- bun run build
- git diff --check