### PR TITLE
Harden P0 filesystem safety paths

### DIFF
--- a/docs/product-quality/public-feedback-snapshot-2026-06-15.md
+++ b/docs/product-quality/public-feedback-snapshot-2026-06-15.md
@@ -70,3 +70,26 @@ gaps are resolved.
 
 Boundary: this snapshot is not production readiness, release readiness,
 external validation, hosted workflow proof, or autonomous reliability evidence.
+
+## Late Follow-Up Signals
+
+An additional owner-provided community thread on 2026-06-15 reinforced the same
+public-readiness priorities and added two sharper trust signals:
+
+- Early readers check commit/star history and provenance before trying the
+  tool; the public surface should explain the private-to-public transition
+  without implying a fully original CLI implementation.
+- The OpenClaude/Codex/Claude Code comparison should not become the product
+  thesis. Public copy should make clear that OpenClaude is the runtime
+  substrate, while the differentiating work is Meta, MFH, Orchestra, and the
+  drift/improvement loop above the CLI.
+- Claude Code-derived ancestry remains a legal/provenance risk that needs
+  explicit review before stronger promotion. If the substrate risk becomes too
+  high, evaluate a cleaner open CLI substrate rather than over-marketing the
+  fork.
+- Reviewers again flagged AGENTS.md/local-path hygiene, dead-code-like
+  Metaforge or AVF wiring, marker-only audits, duplicate product scripts, and
+  the need to keep Korean docs current.
+- The positive signal remains the workflow shape: generate evidence, verify it,
+  record versions, and keep CodeQL in CI. The next work should turn that shape
+  into behavioral tests and smaller security/refactor patches.

--- a/docs/product-quality/public-feedback-triage-2026-06-15.md
+++ b/docs/product-quality/public-feedback-triage-2026-06-15.md
@@ -106,6 +106,12 @@ quality docs; the durable signals are:
   Lumin Repo Lens as a topology reference with manual false-positive review.
 - CodeQL being present in CI is a positive signal, but source-controlled
   configuration is not the same as inspected hosted execution evidence.
+- Later comments also recommended simplifying public workflow language where
+  possible: GStack, GSD, and Superpowers may remain separated internally, but
+  public docs should avoid making the operating stack look like rule sprawl.
+- The latest security/refactor response lane is to start with P0 CodeQL alerts
+  and tiny TDD-backed fixes, then use hosted CodeQL feedback before claiming an
+  alert class is closed.
 
 Current response in this slice:
 

--- a/src/utils/readFileInRange.test.ts
+++ b/src/utils/readFileInRange.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+test('readFileInRange fast path reads from the same opened file it stats', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-read-range-race-'))
+  const testPath = join(tempDir, 'readFileInRange-race.test.ts')
+  const moduleUrl = pathToFileURL(
+    join(process.cwd(), 'src/utils/readFileInRange.ts'),
+  ).href
+
+  try {
+    writeFileSync(
+      testPath,
+      `
+        import { expect, mock, test } from 'bun:test'
+
+        test('isolated fs race regression', async () => {
+          const originalText = 'original line 1\\noriginal line 2'
+          const replacementText = 'replacement line 1\\nreplacement line 2'
+          const calls = {
+            close: 0,
+            handleReadFile: 0,
+            pathReadFile: 0,
+          }
+          const stats = {
+            isDirectory: () => false,
+            isFile: () => true,
+            mtimeMs: 42,
+            size: Buffer.byteLength(originalText),
+          }
+
+          const fsPromisesMock = {
+            open: async () => ({
+              stat: async () => stats,
+              readFile: async () => {
+                calls.handleReadFile++
+                return originalText
+              },
+              close: async () => {
+                calls.close++
+              },
+            }),
+            readFile: async () => {
+              calls.pathReadFile++
+              return replacementText
+            },
+            stat: async () => stats,
+          }
+          mock.module('fs/promises', () => fsPromisesMock)
+
+          const { readFileInRange } = await import(
+            ${JSON.stringify(moduleUrl)} + '?ts=' + Date.now() + '-' + Math.random()
+          )
+
+          const result = await readFileInRange('race.txt', 0, 2)
+          expect(result.content).toBe(originalText)
+          expect(calls.pathReadFile).toBe(0)
+          expect(calls.handleReadFile).toBe(1)
+          expect(calls.close).toBe(1)
+        })
+      `,
+    )
+
+    const result = spawnSync(process.execPath, ['test', testPath], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    })
+
+    if (result.status !== 0) {
+      expect(`${result.stdout}\n${result.stderr}`).toBe('')
+    }
+    expect(result.status).toBe(0)
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+})

--- a/src/utils/readFileInRange.ts
+++ b/src/utils/readFileInRange.ts
@@ -38,7 +38,7 @@
 // ---------------------------------------------------------------------------
 
 import { createReadStream, fstat } from 'fs'
-import { stat as fsStat, readFile } from 'fs/promises'
+import { open as fsOpen } from 'fs/promises'
 import { formatFileSize } from './format.js'
 
 const FAST_PATH_MAX_SIZE = 10 * 1024 * 1024 // 10 MB
@@ -81,34 +81,39 @@ export async function readFileInRange(
   signal?.throwIfAborted()
   const truncateOnByteLimit = options?.truncateOnByteLimit ?? false
 
-  // stat to decide the code path and guard against OOM.
-  // For regular files under 10 MB: readFile + in-memory split (fast).
-  // Everything else (large files, FIFOs, devices): streaming.
-  const stats = await fsStat(filePath)
+  const fileHandle = await fsOpen(filePath, 'r')
+  try {
+    // fstat the opened file to decide the code path and guard against OOM.
+    // For regular files under 10 MB: FileHandle.readFile + in-memory split.
+    // Everything else (large files, FIFOs, devices): streaming.
+    const stats = await fileHandle.stat()
 
-  if (stats.isDirectory()) {
-    throw new Error(
-      `EISDIR: illegal operation on a directory, read '${filePath}'`,
-    )
-  }
-
-  if (stats.isFile() && stats.size < FAST_PATH_MAX_SIZE) {
-    if (
-      !truncateOnByteLimit &&
-      maxBytes !== undefined &&
-      stats.size > maxBytes
-    ) {
-      throw new FileTooLargeError(stats.size, maxBytes)
+    if (stats.isDirectory()) {
+      throw new Error(
+        `EISDIR: illegal operation on a directory, read '${filePath}'`,
+      )
     }
 
-    const text = await readFile(filePath, { encoding: 'utf8', signal })
-    return readFileInRangeFast(
-      text,
-      stats.mtimeMs,
-      offset,
-      maxLines,
-      truncateOnByteLimit ? maxBytes : undefined,
-    )
+    if (stats.isFile() && stats.size < FAST_PATH_MAX_SIZE) {
+      if (
+        !truncateOnByteLimit &&
+        maxBytes !== undefined &&
+        stats.size > maxBytes
+      ) {
+        throw new FileTooLargeError(stats.size, maxBytes)
+      }
+
+      const text = await fileHandle.readFile({ encoding: 'utf8', signal })
+      return readFileInRangeFast(
+        text,
+        stats.mtimeMs,
+        offset,
+        maxLines,
+        truncateOnByteLimit ? maxBytes : undefined,
+      )
+    }
+  } finally {
+    await fileHandle.close()
   }
 
   return readFileInRangeStreaming(

--- a/src/utils/screenshotClipboard.test.ts
+++ b/src/utils/screenshotClipboard.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, statSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import { writeScreenshotTempPng } from './screenshotClipboard'
+
+const tempRoots: string[] = []
+
+function makeTempRoot(): string {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'openclaude-screenshot-test-'))
+  tempRoots.push(tempRoot)
+  return tempRoot
+}
+
+afterEach(() => {
+  for (const tempRoot of tempRoots.splice(0)) {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('writeScreenshotTempPng creates a private unique temp directory and cleanup handle', async () => {
+  const tempRoot = makeTempRoot()
+
+  const first = await writeScreenshotTempPng(Buffer.from([0x89, 0x50]), tempRoot)
+  const second = await writeScreenshotTempPng(Buffer.from([0x89, 0x51]), tempRoot)
+
+  expect(dirname(first.pngPath)).toBe(first.tempDir)
+  expect(dirname(second.pngPath)).toBe(second.tempDir)
+  expect(first.tempDir).not.toBe(second.tempDir)
+  expect(basename(first.tempDir).startsWith('claude-code-screenshot-')).toBe(true)
+  expect(basename(first.pngPath)).toBe('screenshot.png')
+  expect(existsSync(first.pngPath)).toBe(true)
+
+  if (process.platform !== 'win32') {
+    expect(statSync(first.pngPath).mode & 0o077).toBe(0)
+  }
+
+  await first.dispose()
+  expect(existsSync(first.tempDir)).toBe(false)
+
+  await second.dispose()
+})

--- a/src/utils/screenshotClipboard.ts
+++ b/src/utils/screenshotClipboard.ts
@@ -1,4 +1,4 @@
-import { mkdir, unlink, writeFile } from 'fs/promises'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { type AnsiToPngOptions, ansiToPng } from './ansiToPng.js'
@@ -17,29 +17,46 @@ export async function copyAnsiToClipboard(
   ansiText: string,
   options?: AnsiToPngOptions,
 ): Promise<{ success: boolean; message: string }> {
+  let tempPng: ScreenshotTempPng | undefined
   try {
-    const tempDir = join(tmpdir(), 'claude-code-screenshots')
-    await mkdir(tempDir, { recursive: true })
-
-    const pngPath = join(tempDir, `screenshot-${Date.now()}.png`)
     const pngBuffer = ansiToPng(ansiText, options)
-    await writeFile(pngPath, pngBuffer)
-
-    const result = await copyPngToClipboard(pngPath)
-
-    try {
-      await unlink(pngPath)
-    } catch {
-      // Ignore cleanup errors
-    }
-
-    return result
+    tempPng = await writeScreenshotTempPng(pngBuffer)
+    return await copyPngToClipboard(tempPng.pngPath)
   } catch (error) {
     logError(error)
     return {
       success: false,
       message: `Failed to copy screenshot: ${error instanceof Error ? error.message : 'Unknown error'}`,
     }
+  } finally {
+    if (tempPng) {
+      try {
+        await tempPng.dispose()
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}
+
+export type ScreenshotTempPng = {
+  tempDir: string
+  pngPath: string
+  dispose: () => Promise<void>
+}
+
+export async function writeScreenshotTempPng(
+  pngBuffer: Buffer,
+  tempRoot = tmpdir(),
+): Promise<ScreenshotTempPng> {
+  const tempDir = await mkdtemp(join(tempRoot, 'claude-code-screenshot-'))
+  const pngPath = join(tempDir, 'screenshot.png')
+  await writeFile(pngPath, pngBuffer, { flag: 'wx', mode: 0o600 })
+
+  return {
+    tempDir,
+    pngPath,
+    dispose: () => rm(tempDir, { recursive: true, force: true }),
   }
 }
 


### PR DESCRIPTION
## Summary
- Save the latest public feedback as public-safe product-quality notes, keeping Metaforge as the Meta/MFH/Orchestra thesis and OpenClaude as runtime substrate.
- Replace predictable screenshot temp paths with a unique `mkdtemp` directory plus exclusive/private `screenshot.png` writes and cleanup.
- Move the `readFileInRange` fast path from path `stat` + path `readFile` to `FileHandle.stat()` + `FileHandle.readFile()` on the same opened file.

## Verification
- `bun test src/utils/readFileInRange.test.ts src/utils/screenshotClipboard.test.ts src/utils/sessionStorage.test.ts src/utils/execFileNoThrow.test.ts`
- `bun run typecheck --pretty false`
- `bun run verify:privacy`
- `git diff --check`

## Claim Boundary
- This is a local P0 filesystem-safety remediation slice and feedback-preservation update.
- It does not claim CodeQL alert closure, production readiness, release readiness, or external validation until hosted CodeQL confirms the target branch.

## Primary Sources
- CodeQL `js/insecure-temporary-file`: https://codeql.github.com/codeql-query-help/javascript/js-insecure-temporary-file/
- CodeQL `js/file-system-race`: https://codeql.github.com/codeql-query-help/javascript/js-file-system-race/
- Node.js `fs` docs: https://nodejs.org/api/fs.html