### PR TITLE
Harden plugin ZIP extraction writes

### DIFF
--- a/src/utils/plugins/zipCache.test.ts
+++ b/src/utils/plugins/zipCache.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, test } from 'bun:test'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createZipFromDirectory, extractZipToDirectory } from './zipCache'
+
+const tempDirs: string[] = []
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-zip-cache-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+test('extractZipToDirectory refuses to overwrite an existing extracted file', async () => {
+  const root = await makeTempDir()
+  const sourceDir = join(root, 'source')
+  const targetDir = join(root, 'target')
+  const fileName = 'plugin.txt'
+  const targetFile = join(targetDir, fileName)
+
+  await mkdir(sourceDir)
+  await mkdir(targetDir)
+  await writeFile(join(sourceDir, fileName), 'from zip', 'utf8')
+  await writeFile(targetFile, 'existing', 'utf8')
+
+  const zipPath = join(root, 'plugin.zip')
+  const zipData = await createZipFromDirectory(sourceDir)
+  await writeFile(zipPath, zipData)
+
+  await expect(extractZipToDirectory(zipPath, targetDir)).rejects.toThrow()
+  await expect(readFile(targetFile, 'utf8')).resolves.toBe('existing')
+})

--- a/src/utils/plugins/zipCache.ts
+++ b/src/utils/plugins/zipCache.ts
@@ -349,7 +349,7 @@ export async function extractZipToDirectory(
 
     const fullPath = join(targetDir, relPath)
     await getFsImplementation().mkdir(dirname(fullPath))
-    await writeFile(fullPath, data)
+    await writeFile(fullPath, data, { flag: 'wx', mode: 0o600 })
     const mode = modes[relPath]
     if (mode && mode & 0o111) {
       // Swallow EPERM/ENOTSUP (NFS root_squash, some FUSE mounts) — losing +x


### PR DESCRIPTION
## Summary
- Harden plugin ZIP extraction so extracted files are created with exclusive writes instead of overwriting existing files.
- Add a regression test proving `extractZipToDirectory` refuses to overwrite a pre-existing extracted file and preserves the existing content.

## Verification
- `bun test src/utils/plugins/zipCache.test.ts`
- `bun test src/utils/plugins/zipCache.test.ts src/utils/readFileInRange.test.ts src/utils/screenshotClipboard.test.ts`
- `bun run typecheck --pretty false`
- `bun run verify:privacy`
- `git diff --check`

## Claim Boundary
- This is a local P0 filesystem-safety slice for plugin ZIP extraction.
- It does not claim CodeQL alert closure, public security posture, production readiness, release readiness, or external validation until hosted CodeQL confirms the target branch.

## Primary Sources
- CodeQL `js/insecure-temporary-file`: https://codeql.github.com/codeql-query-help/javascript/js-insecure-temporary-file/
- CodeQL `js/file-system-race`: https://codeql.github.com/codeql-query-help/javascript/js-file-system-race/
- GitHub code scanning alert management: https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-code-scanning-alerts