### PR TITLE
Harden public local model hints

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -90,7 +90,7 @@ OpenRouter model availability changes over time. If a model stops working, try a
 Using `ollama launch` (recommended if you have Ollama installed):
 
 ```bash
-ollama launch openclaude --model llama3.3:70b
+ollama launch openclaude --model <local-ollama-model>
 ```
 
 This handles all environment setup automatically — no env vars needed. Works with any local or cloud model available in your Ollama instance.
@@ -98,11 +98,11 @@ This handles all environment setup automatically — no env vars needed. Works w
 Using environment variables manually:
 
 ```bash
-ollama pull llama3.3:70b
+ollama pull <local-ollama-model>
 
 export CLAUDE_CODE_USE_OPENAI=1
 export OPENAI_BASE_URL=http://localhost:11434/v1
-export OPENAI_MODEL=llama3.3:70b
+export OPENAI_MODEL=<local-ollama-model>
 ```
 
 ### Atomic Chat (local, Apple Silicon)
@@ -172,7 +172,7 @@ export OPENAI_MODEL=<azure-openai-deployment>
 |----------|----------|-------------|
 | `CLAUDE_CODE_USE_OPENAI` | Yes | Set to `1` to enable the OpenAI provider |
 | `OPENAI_API_KEY` | Yes* | Your API key (`*` not needed for local models like Ollama or Atomic Chat) |
-| `OPENAI_MODEL` | Yes | Model or deployment name such as `<current-openai-tool-model>`, `deepseek-chat`, or `llama3.3:70b` |
+| `OPENAI_MODEL` | Yes | Model, alias, or deployment name such as `<current-openai-tool-model>`, `<local-ollama-model>`, or `deepseek-chat` |
 | `OPENAI_BASE_URL` | No | API endpoint, defaulting to `https://api.openai.com/v1` |
 | `CODEX_API_KEY` | Codex only | Codex or ChatGPT access token override |
 | `CODEX_AUTH_JSON_PATH` | Codex only | Path to a Codex CLI `auth.json` file |

--- a/scripts/provider-recommend.ts
+++ b/scripts/provider-recommend.ts
@@ -255,7 +255,7 @@ async function main(): Promise<void> {
       '\nNo local Ollama model was detected and OPENAI_API_KEY is unset.',
     )
     console.log(
-      'Next steps: `ollama pull qwen2.5-coder:7b` or set OPENAI_API_KEY.',
+      'Next steps: `ollama pull <local-ollama-model>` or set OPENAI_API_KEY.',
     )
   }
 }

--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -65,4 +65,17 @@ describe('public artifact hygiene scanner', () => {
     expect(result.status).not.toBe(0)
     expect(`${result.stdout}\n${result.stderr}`).toContain('README.md')
   })
+
+  test('scans the root license for local path disclosure', () => {
+    const repo = makeTempRepo()
+    writeFileSync(
+      join(repo, 'LICENSE'),
+      `Derived runtime note copied from ${windowsPrivatePath}\n`,
+    )
+
+    const result = runHygiene(repo)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('LICENSE')
+  })
 })

--- a/scripts/public-artifact-hygiene.ts
+++ b/scripts/public-artifact-hygiene.ts
@@ -22,6 +22,7 @@ const targetRoots = [
   'ANDROID_INSTALL.md',
   'AGENTS.md',
   'PLAYBOOK.md',
+  'LICENSE',
   'vscode-extension/openclaude-vscode/README.md',
   '.env.example',
   'package.json',

--- a/scripts/public-repo-readiness.test.ts
+++ b/scripts/public-repo-readiness.test.ts
@@ -241,6 +241,7 @@ describe('public repository readiness surfaces', () => {
       expect(text, path).not.toMatch(/\byour[_-]?[a-z0-9_-]*key[a-z0-9_-]*\b/i)
       expect(text, path).not.toMatch(/\bqwen\/qwen3\.6-plus-preview:free\b/i)
       expect(text, path).not.toMatch(/\bqwen2\.5-coder\b/i)
+      expect(text, path).not.toMatch(/\bllama3\.3:70b\b/i)
       expect(text, path).not.toMatch(/\bclaude-sonnet-4-5-20250929\b/i)
       expect(text, path).not.toMatch(/~\/\.codex\/auth\.json/i)
       expect(text, path).not.toMatch(/\b(?:current[-\s]?best|best[-\s]?(?:available\s+)?(?:provider|model|benchmark)|recommended\s+(?:free\s+)?(?:provider|model|benchmark))\b/i)
@@ -255,6 +256,19 @@ describe('public repository readiness surfaces', () => {
     expect(docs['docs/litellm-setup.md']).toContain('<current-anthropic-tool-model>')
     expect(docs['PLAYBOOK.md']).toContain('<current-openai-tool-model>')
     expect(docs['PLAYBOOK.md']).toContain('<local-ollama-model>')
+  })
+
+  test('runtime diagnostics do not recommend pinned local model examples', () => {
+    const runtimeHintDocs = {
+      'scripts/system-check.ts': readRepoText('scripts/system-check.ts'),
+      'scripts/provider-recommend.ts': readRepoText('scripts/provider-recommend.ts'),
+    }
+
+    for (const [path, text] of Object.entries(runtimeHintDocs)) {
+      expect(text, path).toContain('<local-ollama-model>')
+      expect(text, path).not.toMatch(/\bqwen2\.5-coder\b/i)
+      expect(text, path).not.toMatch(/\bllama3\.3:70b\b/i)
+    }
   })
 
   test('Android install notes stay legacy-bounded and avoid unsupported superiority claims', () => {

--- a/scripts/system-check.ts
+++ b/scripts/system-check.ts
@@ -483,7 +483,7 @@ async function checkProviderGenerationReadiness(): Promise<CheckResult> {
   if (readiness.state === 'no_models') {
     return fail(
       'Provider generation readiness',
-      'Ollama is reachable, but no installed models were found. Pull a model first (for example: ollama pull qwen2.5-coder:7b).',
+      'Ollama is reachable, but no installed models were found. Pull a local model first (for example: ollama pull <local-ollama-model>).',
     )
   }
 


### PR DESCRIPTION
## Summary
- Replace pinned Ollama examples in advanced setup docs with <local-ollama-model>.
- Remove pinned local model recommendations from runtime doctor/profile recommendation hints.
- Extend public readiness and artifact hygiene tests so stale local model pins and LICENSE path leaks are caught.

## Verification
- bun test scripts/public-artifact-hygiene.test.ts scripts/public-repo-readiness.test.ts scripts/system-check.test.ts scripts/product-origin-license-provenance-boundary.test.ts
- bun run product:public-artifact-hygiene
- bun run typecheck --pretty false
- bun run verify:privacy
- git diff --check

## Boundary
- This does not claim provider/model superiority or live provider validation. It only removes stale public local-model examples and broadens public hygiene scanning.
