### PR TITLE
[codex] Redact private profile evidence breadcrumbs

### DIFF
--- a/docs/profile/github-profile-refresh-evidence-2026-06-14.md
+++ b/docs/profile/github-profile-refresh-evidence-2026-06-14.md
@@ -39,25 +39,13 @@ Observed through GitHub metadata:
 | `svy04/svy04` | public | AI 결과물을 검증 가능한 판단으로 바꾸는 사람 | Profile surface |
 | `svy04/leaderboard-data` | public | Data storage for Rust server leaderboard | Older/supporting, not central |
 
-Current private/internal work that should not be marketed as public access:
-
-- `svy04/mimesis-source-packet`
-- `svy04/mimesis-plugin`
-- `svy04/harness-meta`
-- `svy04/mfh`
-
 ## Private Workbench Evidence
 
-Owner-side private workbench summary. This is not public proof and should not be
-used as a public source path.
-
-Nested repo status:
-
-| Local repo | Remote | Status |
-| --- | --- | --- |
-| `mimesis-plugin` | `https://github.com/svy04/mimesis-plugin.git` | private repo, `master`, HEAD `1cbc7a4`, dirty working tree with modified claim/module files and new case/expert artifacts |
-| `mimesis-source-packet` | `https://github.com/svy04/mimesis-source-packet.git` | private repo, `master`, HEAD `cfaae0e`, dirty working tree with modified paradigm/findings/paper draft files |
-| `testbed/svy04.github.io` | `https://github.com/svy04/svy04.github.io.git` | private repo, untracked hero preview files |
+private workbench repos were checked locally and are not public proof.
+This public packet intentionally omits private repository names, private remote
+URLs, branch names, revision identifiers, worktree cleanliness details, and
+local file inventory. Those details are internal operating context, not public
+marketing evidence.
 
 Profile implication:
 
@@ -69,7 +57,7 @@ Profile implication:
 ## Recommended Profile Positioning
 
 ```text
-오영웅 / svy04
+svy04
 Building Metaforge: a Meta/MFH/Orchestra operating system for governed-code execution.
 
 I work on Mimesis Engineering: importing proven product, paper, patent, OSS, and standard structures into AI-native work, then keeping only what survives evidence gates.
@@ -81,6 +69,6 @@ I work on Mimesis Engineering: importing proven product, paper, patent, OSS, and
 - Done: replaced old project list with current repository evidence.
 - Done: avoided private repository links in the public profile README.
 - Done: GitHub contents API update returned commit SHA `9ff27401ca4c38ed1b55ea4c8480c72496b3bd03`.
-- Done: GitHub API readback confirmed `# 오영웅 · svy04`, `Building **Metaforge**...`, and `## Current Focus`.
+- Done: GitHub API readback confirmed the public handle, `Building **Metaforge**...`, and `## Current Focus`.
 - Done: second profile update linked the Metaforge public proof pack from `## Start Here`.
 - Done: GitHub contents API update returned commit SHA `7c4672a3a4797729d98a6ae161004fef49f0529b`.

--- a/scripts/public-repo-readiness.test.ts
+++ b/scripts/public-repo-readiness.test.ts
@@ -296,6 +296,24 @@ describe('public repository readiness surfaces', () => {
     }
   })
 
+  test('profile refresh evidence does not expose private workbench repo breadcrumbs', () => {
+    const evidence = readRepoText('docs/profile/github-profile-refresh-evidence-2026-06-14.md')
+    const forbiddenEvidence = [
+      'mimesis-plugin',
+      'mimesis-source-packet',
+      'harness-meta',
+      'https://github.com/svy04/mimesis-plugin.git',
+      'https://github.com/svy04/mimesis-source-packet.git',
+      'dirty working tree',
+      'untracked hero preview files',
+    ]
+
+    expect(evidence).toContain('private workbench repos were checked locally and are not public proof')
+    for (const marker of forbiddenEvidence) {
+      expect(evidence, marker).not.toContain(marker)
+    }
+  })
+
   test('legacy VS Code extension README points to the canonical Metaforge extension surface', () => {
     const legacyReadme = readRepoText('vscode-extension/openclaude-vscode/README.md')
 


### PR DESCRIPTION
## Summary
- Redact private workbench repository breadcrumbs from the public-facing profile refresh evidence packet.
- Replace private repo names, private remote URLs, branch/revision/worktree details, and local inventory with a bounded public statement: local private workbench checks are not public proof.
- Add a public-readiness regression test so these private breadcrumbs cannot be reintroduced into the tracked public evidence packet.

## Validation
- RED: `bun test scripts/public-repo-readiness.test.ts --test-name-pattern "profile refresh evidence"` failed before redaction.
- `bun test scripts/public-repo-readiness.test.ts --test-name-pattern "profile refresh evidence"` passed.
- `bun test scripts/public-repo-readiness.test.ts` passed: 18 tests, 177 expects.
- `bun run product:public-artifact-hygiene` passed.
- `bun run product:public-claim-boundary` passed.
- `bun run verify:privacy` passed.
- `bun run typecheck --pretty false` passed.
- `git diff --check` passed.
- `rg -n "mimesis-plugin|mimesis-source-packet|harness-meta|https://github.com/svy04/mimesis-plugin.git|https://github.com/svy04/mimesis-source-packet.git|dirty working tree|untracked hero preview files|오영웅" docs/profile docs/marketing README.md README.ko.md AGENTS.md` found no matches.

## Claim Boundary
This is public evidence hygiene only. It does not claim full-history secret scanning, credential validity, production readiness, release readiness, external validation, or private workbench publication.