### PR TITLE
Test jscpd fixture audit execution

### DIFF
--- a/scripts/product-script-duplication-audit.test.ts
+++ b/scripts/product-script-duplication-audit.test.ts
@@ -116,6 +116,130 @@ function readText(path: string): string {
     ])
   }, 30000)
 
+  test('runs local jscpd against a temp fixture without rewriting checked-in reports', () => {
+    const repo = makeTempRepo()
+    const rootReportBefore = readFileSync(
+      join(root, 'docs', 'product-quality', 'script-duplication-audit-report.json'),
+      'utf8',
+    )
+    const rootMarkdownBefore = readFileSync(
+      join(root, 'docs', 'product-quality', 'script-duplication-audit-report.md'),
+      'utf8',
+    )
+    const clonedSource = `
+type Check = { label: string; ok: boolean; detail: string }
+function check(label: string, ok: boolean, detail: string): Check {
+  return { label, ok, detail }
+}
+function readText(path: string): string {
+  return path.trim()
+}
+export function renderFixtureReport(input: string): string {
+  const rows = [
+    'alpha',
+    'beta',
+    'gamma',
+    'delta',
+    'epsilon',
+    'zeta',
+    'eta',
+    'theta',
+    'iota',
+    'kappa',
+  ]
+  return rows.map((row, index) => \`\${index}:\${row}:\${input}\`).join('\\n')
+}
+`
+    const uniqueSource = Array.from(
+      { length: 1400 },
+      (_, index) => `export const uniqueFixtureValue${index} = ${index} * ${index + 17}`,
+    ).join('\n')
+    writeFileSync(join(repo, '.jscpd.json'), JSON.stringify({
+      path: ['scripts'],
+      pattern: '**/product-*.ts',
+      format: ['typescript'],
+      reporters: ['json'],
+      minLines: 5,
+      minTokens: 20,
+      absolute: false,
+      gitignore: false,
+    }, null, 2))
+    writeFileSync(join(repo, 'scripts', 'product-alpha.ts'), clonedSource)
+    writeFileSync(join(repo, 'scripts', 'product-beta.ts'), clonedSource)
+    writeFileSync(join(repo, 'scripts', 'product-unique.ts'), uniqueSource)
+
+    const result = runAudit(repo)
+
+    expect(result.status, result.stderr || result.stdout).toBe(0)
+    expect(result.stdout).toContain('RESULT: PASS')
+
+    const tempReportText = readFileSync(
+      join(repo, 'docs', 'product-quality', 'script-duplication-audit-report.json'),
+      'utf8',
+    )
+    const tempReport = JSON.parse(tempReportText) as {
+      jscpdEnabled: boolean
+      jscpdVersion: string
+      jscpdCommand: {
+        name: string
+        command: string[]
+        exitCode: number | null
+        passed: boolean
+        missingSubstrings: string[]
+      }
+      jscpdReportSha256: string
+      jscpdCloneCount: number
+      jscpdCloneBaseline: number
+      jscpdDuplicatedLines: number
+      jscpdDuplicatedLinesBaseline: number
+      jscpdDuplicatedTokens: number
+      jscpdDuplicatedTokensBaseline: number
+      jscpdDuplicatedPercentage: number
+      jscpdDuplicatedPercentageBaseline: number
+      jscpdTopClonePairs: Array<{
+        firstFile: string
+        secondFile: string
+      }>
+    }
+    expect(tempReport.jscpdEnabled).toBe(true)
+    expect(tempReport.jscpdVersion).toContain('5.0.9')
+    expect(tempReport.jscpdCommand.name).toBe('jscpd_product_scripts_json')
+    expect(tempReport.jscpdCommand.command).toEqual(
+      expect.arrayContaining(['jscpd', '--config', '.jscpd.json', '--reporters', 'json']),
+    )
+    expect(tempReport.jscpdCommand.exitCode).toBe(0)
+    expect(tempReport.jscpdCommand.passed).toBe(true)
+    expect(tempReport.jscpdCommand.missingSubstrings).toEqual([])
+    expect(tempReport.jscpdReportSha256).toHaveLength(64)
+    expect(tempReport.jscpdReportSha256).not.toBe('0'.repeat(64))
+    expect(tempReport.jscpdCloneCount).toBeGreaterThan(0)
+    expect(tempReport.jscpdCloneCount).toBeLessThanOrEqual(tempReport.jscpdCloneBaseline)
+    expect(tempReport.jscpdDuplicatedLines).toBeGreaterThan(0)
+    expect(tempReport.jscpdDuplicatedLines).toBeLessThanOrEqual(tempReport.jscpdDuplicatedLinesBaseline)
+    expect(tempReport.jscpdDuplicatedTokens).toBeGreaterThan(0)
+    expect(tempReport.jscpdDuplicatedTokens).toBeLessThanOrEqual(tempReport.jscpdDuplicatedTokensBaseline)
+    expect(tempReport.jscpdDuplicatedPercentage).toBeGreaterThan(0)
+    expect(tempReport.jscpdDuplicatedPercentage).toBeLessThanOrEqual(tempReport.jscpdDuplicatedPercentageBaseline)
+    expect(tempReport.jscpdTopClonePairs.length).toBeGreaterThan(0)
+    expect(
+      tempReport.jscpdTopClonePairs.every(
+        (pair) =>
+          pair.firstFile.startsWith('scripts/') &&
+          pair.secondFile.startsWith('scripts/') &&
+          !pair.firstFile.includes('\\') &&
+          !pair.secondFile.includes('\\') &&
+          !pair.firstFile.includes(repo) &&
+          !pair.secondFile.includes(repo),
+      ),
+    ).toBe(true)
+    expect(readFileSync(join(root, 'docs', 'product-quality', 'script-duplication-audit-report.json'), 'utf8')).toBe(
+      rootReportBefore,
+    )
+    expect(readFileSync(join(root, 'docs', 'product-quality', 'script-duplication-audit-report.md'), 'utf8')).toBe(
+      rootMarkdownBefore,
+    )
+  }, 60000)
+
   test('records jscpd token-clone ratchet evidence for product scripts without cleanup claims', () => {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
       devDependencies: Record<string, string>

--- a/scripts/product-script-duplication-audit.ts
+++ b/scripts/product-script-duplication-audit.ts
@@ -2,7 +2,8 @@ import { createHash } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 type HelperOccurrence = {
   helperName: string
@@ -129,6 +130,7 @@ type ScriptDuplicationAuditReport = {
 }
 
 const root = process.cwd()
+const toolPackageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const docsDir = resolve(root, 'docs/product-quality')
 const scriptsDir = resolve(root, 'scripts')
 const jscpdConfigPath = '.jscpd.json'
@@ -173,11 +175,20 @@ function preview(input: string): string {
   return scrubLocalPaths(input).slice(0, 800)
 }
 
-function localJscpdBinaryExists(): boolean {
+function localJscpdBinaryPath(): string | null {
   const binNames = process.platform === 'win32'
-    ? ['jscpd.cmd', 'jscpd.exe', 'jscpd.bunx']
+    ? ['jscpd.exe', 'jscpd.cmd', 'jscpd.bunx']
     : ['jscpd']
-  return binNames.some((binName) => existsSync(resolve(root, 'node_modules/.bin', binName)))
+  const searchRoots = [...new Set([root, toolPackageRoot])]
+  for (const searchRoot of searchRoots) {
+    for (const binName of binNames) {
+      const candidate = resolve(searchRoot, 'node_modules/.bin', binName)
+      if (existsSync(candidate)) {
+        return candidate
+      }
+    }
+  }
+  return null
 }
 
 function sanitizedEnv(): NodeJS.ProcessEnv {
@@ -275,11 +286,12 @@ function buildJscpdEvidence() {
   if (!existsSync(resolve(root, jscpdConfigPath))) {
     return emptyJscpdEvidence(disabledCommand('jscpd_product_scripts_json', 'jscpd config absent in this test fixture'))
   }
-  if (!localJscpdBinaryExists()) {
+  const jscpdBinaryPath = localJscpdBinaryPath()
+  if (!jscpdBinaryPath) {
     return emptyJscpdEvidence(disabledCommand('jscpd_product_scripts_json', 'local jscpd binary missing'), true)
   }
 
-  const versionResult = spawnSync(process.execPath, ['run', 'jscpd', '--version'], {
+  const versionResult = spawnSync(jscpdBinaryPath, ['--version'], {
     cwd: root,
     encoding: 'utf8',
     env: sanitizedEnv(),
@@ -294,8 +306,8 @@ function buildJscpdEvidence() {
     const command = runAuditCommand(
       'jscpd_product_scripts_json',
       ['jscpd', '--config', jscpdConfigPath, '--reporters', 'json', '--output', '<temp-jscpd-output>', '--no-tips'],
-      process.execPath,
-      ['run', 'jscpd', '--config', jscpdConfigPath, '--reporters', 'json', '--output', outputDir, '--no-tips'],
+      jscpdBinaryPath,
+      ['--config', jscpdConfigPath, '--reporters', 'json', '--output', outputDir, '--no-tips'],
       ['Using config from .jscpd.json', 'JSON report saved'],
     )
 


### PR DESCRIPTION
﻿## Summary
- resolve the repo-installed jscpd binary from the audit script package root when the audit runs in a temp fixture repo
- add a behavior test that runs jscpd against a temp product-script fixture and proves the checked-in root reports are not rewritten
- keep this scoped to harness confidence; no public readiness, cleanup-complete, or external validation claim changes

## Source Basis
- jscpd upstream supports the `jscpd` CLI, `.jscpd.json` config, and JSON reporters: https://github.com/kucherenko/jscpd

## Verification
- `bun test scripts/product-script-duplication-audit.test.ts -t "runs local jscpd against a temp fixture without rewriting checked-in reports"`
- `bun test scripts/product-script-duplication-audit.test.ts`
- `bun run product:script-duplication-audit`
- `bun run build`
- `bun run typecheck --pretty false`
- `bun run scripts/product-quality-gate.ts`
- `bun run verify:privacy`
- `bun run product:quality`
- `git diff --check`
- changed-file scan for local paths / secret-looking strings

## Notes
- Full `product:quality` passed, with the existing terminal condition still recorded as `PRODUCT_QUALITY_GATE_BLOCKED_BY_LOCAL_VSCODE_CLI_UNAVAILABLE` for protected/claim-boundary purposes.
- I intentionally did not update the profile README because this does not move public metrics or claim boundaries.
