### PR TITLE
Harden public hygiene manifest coverage

### DIFF
--- a/scripts/product-public-claim-boundary.test.ts
+++ b/scripts/product-public-claim-boundary.test.ts
@@ -28,6 +28,11 @@ describe('product public claim boundary classifier', () => {
     expect(publicSurfacePaths).toContain('AGENTS.md')
   })
 
+  test('includes extension package manifests in public claim-boundary surfaces', () => {
+    expect(publicSurfacePaths).toContain('packages/openclaude-vscode/package.json')
+    expect(publicSurfacePaths).toContain('vscode-extension/openclaude-vscode/package.json')
+  })
+
   test('classifies unsupported public-readiness claims as unauthorized positives', () => {
     const findings = scanClaimText(
       'README.md',
@@ -43,6 +48,28 @@ describe('product public claim boundary classifier', () => {
     expect(findings.map((finding) => finding.category).sort()).toEqual([
       'production_readiness',
       'public_readiness',
+    ])
+  })
+
+  test('classifies unsupported package manifest claims as unauthorized positives', () => {
+    const manifestText = JSON.stringify(
+      {
+        description: 'OpenClaude extension package is production-ready and externally validated.',
+      },
+      null,
+      2,
+    )
+    const findings = scanClaimText('packages/openclaude-vscode/package.json', manifestText)
+
+    expect(findings.map((finding) => finding.status)).toEqual(
+      expect.arrayContaining([
+        'unauthorized_positive_claim',
+        'unauthorized_positive_claim',
+      ]),
+    )
+    expect(findings.map((finding) => finding.category).sort()).toEqual([
+      'external_validation',
+      'production_readiness',
     ])
   })
 

--- a/scripts/product-public-claim-boundary.ts
+++ b/scripts/product-public-claim-boundary.ts
@@ -108,7 +108,9 @@ export const publicSurfacePaths = [
   'docs/MIMESIS_ENGINEERING.md',
   'docs/marketing/metaforge-public-proof-pack-2026-06-14.md',
   'docs/research/public-proof-pack-source-ledger-2026-06-14.md',
+  'packages/openclaude-vscode/package.json',
   'packages/openclaude-vscode/README.md',
+  'vscode-extension/openclaude-vscode/package.json',
   'vscode-extension/openclaude-vscode/README.md',
 ]
 

--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -114,6 +114,40 @@ describe('public artifact hygiene scanner', () => {
     expect(`${result.stdout}\n${result.stderr}`).toContain('LICENSE')
   })
 
+  test('scans root support docs for local path disclosure', () => {
+    const repo = makeTempRepo()
+    writeFileSync(
+      join(repo, 'SUPPORT.md'),
+      `Support packet copied from ${windowsPrivatePath}\n`,
+    )
+
+    const result = runHygiene(repo)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('SUPPORT.md')
+  })
+
+  test('rejects actual-looking public credential tokens', () => {
+    const repo = makeTempRepo()
+    const githubToken = 'ghp_' + 'A'.repeat(36)
+    const awsKey = 'AKIA' + 'A'.repeat(16)
+    const slackToken = 'xoxb-' + 'A'.repeat(12)
+    writeFileSync(
+      join(repo, 'README.md'),
+      [
+        `GITHUB_TOKEN=${githubToken}`,
+        `AWS_ACCESS_KEY_ID=${awsKey}`,
+        `SLACK_BOT_TOKEN=${slackToken}`,
+      ].join('\n'),
+    )
+
+    const result = runHygiene(repo)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('README.md')
+    expect(`${result.stdout}\n${result.stderr}`).toContain('github-token')
+  })
+
   test('scans the canonical VS Code extension README for local path disclosure', () => {
     const repo = makeTempRepo()
     const extensionDir = join(repo, 'packages', 'openclaude-vscode')
@@ -127,5 +161,35 @@ describe('public artifact hygiene scanner', () => {
 
     expect(result.status).not.toBe(0)
     expect(`${result.stdout}\n${result.stderr}`).toContain('packages/openclaude-vscode/README.md')
+  })
+
+  test('scans the canonical VS Code extension package manifest for local path disclosure', () => {
+    const repo = makeTempRepo()
+    const extensionDir = join(repo, 'packages', 'openclaude-vscode')
+    mkdirSync(extensionDir, { recursive: true })
+    writeFileSync(
+      join(extensionDir, 'package.json'),
+      JSON.stringify({ description: `Derived runtime note copied from ${windowsPrivatePath}` }),
+    )
+
+    const result = runHygiene(repo)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('packages/openclaude-vscode/package.json')
+  })
+
+  test('scans the legacy VS Code extension package manifest for local path disclosure', () => {
+    const repo = makeTempRepo()
+    const extensionDir = join(repo, 'vscode-extension', 'openclaude-vscode')
+    mkdirSync(extensionDir, { recursive: true })
+    writeFileSync(
+      join(extensionDir, 'package.json'),
+      JSON.stringify({ description: `Derived runtime note copied from ${windowsPrivatePath}` }),
+    )
+
+    const result = runHygiene(repo)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('vscode-extension/openclaude-vscode/package.json')
   })
 })

--- a/scripts/public-artifact-hygiene.ts
+++ b/scripts/public-artifact-hygiene.ts
@@ -22,8 +22,14 @@ const targetRoots = [
   'ANDROID_INSTALL.md',
   'AGENTS.md',
   'PLAYBOOK.md',
+  'CHANGELOG.md',
+  'CONTRIBUTING.md',
+  'SECURITY.md',
+  'SUPPORT.md',
   'LICENSE',
+  'packages/openclaude-vscode/package.json',
   'packages/openclaude-vscode/README.md',
+  'vscode-extension/openclaude-vscode/package.json',
   'vscode-extension/openclaude-vscode/README.md',
   '.env.example',
   'package.json',
@@ -44,6 +50,11 @@ const textExtensions = new Set([
 type Replacement = {
   pattern: RegExp
   replacement: string
+}
+
+type PublicLeakPattern = {
+  label: string
+  pattern: RegExp
 }
 
 const sep = String.raw`(?:\\+|/)`
@@ -97,29 +108,35 @@ const replacements: Replacement[] = [
   },
 ]
 
-const forbiddenPatterns = [
-  /C:(?:\\{1,2}|\/)Users(?:\\{1,2}|\/)[^\\/\s"']+/,
-  /\/Users\/[^/\s"']+/,
-  /Users\/[^/\s"']+/,
-  new RegExp(String.raw`\uB0B4\u0020\uC21C\uC218\u0020\uC7AC\uBBF8`),
-  new RegExp('Digital ' + 'Factory'),
-  new RegExp(String.raw`\.` + 'codex' + String.raw`[\\/]+` + 'memories', 'i'),
-  new RegExp(String.raw`\.` + 'agents' + String.raw`[\\/]+` + 'skills', 'i'),
-  new RegExp(privateWorkspacePlaceholder, 'i'),
-  /(?:^|[\s`"'])meta[\\/]+CLAUDE\.md\b/i,
-  /(?:^|[\s`"'])mfh[\\/]+\.mfh[\\/]+spec\.md\b/i,
-  new RegExp('OpenClaude Orchestrator ' + 'Memory'),
-  new RegExp('AGENTS\\.md instructions for C' + ':'),
-  new RegExp('<codex_' + 'internal_context\\b', 'i'),
-  new RegExp('<environment_' + 'context\\b', 'i'),
-  new RegExp('<workspace_' + 'roots\\b', 'i'),
-  new RegExp('<permissions ' + 'instructions\\b', 'i'),
-  new RegExp('갤로그로 ' + '이동합니다|댓글' + '돌이'),
-  new RegExp('Token: ' + 'gho_'),
-  /\bsk-\.\.\./i,
-  /\byour[_-]?[a-z0-9_-]*key[a-z0-9_-]*\b/i,
-  /(?:api[-_\s]?key|token)[^\r\n]{0,80}\bsk-[A-Za-z0-9_-]{8,}\b/i,
-  new RegExp('session' + '_id'),
+const customPublicLeakPatterns: PublicLeakPattern[] = [
+  { label: 'windows-user-path', pattern: /C:(?:\\{1,2}|\/)Users(?:\\{1,2}|\/)[^\\/\s"']+/ },
+  { label: 'posix-user-path', pattern: /\/Users\/[^/\s"']+/ },
+  { label: 'relative-user-path', pattern: /Users\/[^/\s"']+/ },
+  { label: 'private-workspace-korean-name', pattern: new RegExp(String.raw`\uB0B4\u0020\uC21C\uC218\u0020\uC7AC\uBBF8`) },
+  { label: 'private-workspace-name', pattern: new RegExp('Digital ' + 'Factory') },
+  { label: 'codex-memory-path', pattern: new RegExp(String.raw`\.` + 'codex' + String.raw`[\\/]+` + 'memories', 'i') },
+  { label: 'agents-skill-path', pattern: new RegExp(String.raw`\.` + 'agents' + String.raw`[\\/]+` + 'skills', 'i') },
+  { label: 'private-workspace-placeholder', pattern: new RegExp(privateWorkspacePlaceholder, 'i') },
+  { label: 'private-meta-authority-path', pattern: /(?:^|[\s`"'])meta[\\/]+CLAUDE\.md\b/i },
+  { label: 'private-mfh-spec-path', pattern: /(?:^|[\s`"'])mfh[\\/]+\.mfh[\\/]+spec\.md\b/i },
+  { label: 'private-memory-dump-title', pattern: new RegExp('OpenClaude Orchestrator ' + 'Memory') },
+  { label: 'pasted-agents-local-context', pattern: new RegExp('AGENTS\\.md instructions for C' + ':') },
+  { label: 'codex-internal-context', pattern: new RegExp('<codex_' + 'internal_context\\b', 'i') },
+  { label: 'environment-context', pattern: new RegExp('<environment_' + 'context\\b', 'i') },
+  { label: 'workspace-roots-context', pattern: new RegExp('<workspace_' + 'roots\\b', 'i') },
+  { label: 'permissions-instructions-context', pattern: new RegExp('<permissions ' + 'instructions\\b', 'i') },
+  { label: 'raw-public-comment-ui-dump', pattern: new RegExp('갤로그로 ' + '이동합니다|댓글' + '돌이') },
+  { label: 'github-oauth-token-label', pattern: new RegExp('Token: ' + 'gho_') },
+  { label: 'github-token', pattern: /\bgh[pousr]_[A-Za-z0-9_]{30,}\b/ },
+  { label: 'github-fine-grained-token', pattern: /\bgithub_pat_[A-Za-z0-9_]{30,}\b/ },
+  { label: 'aws-access-key', pattern: /\bAKIA[0-9A-Z]{16}\b/ },
+  { label: 'aws-session-access-key', pattern: /\bASIA[0-9A-Z]{16}\b/ },
+  { label: 'slack-token', pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  { label: 'private-key-block', pattern: /-----BEGIN (?:RSA|DSA|EC|OPENSSH|PGP) PRIVATE KEY-----/ },
+  { label: 'scanner-unfriendly-openai-key-placeholder', pattern: /\bsk-\.\.\./i },
+  { label: 'scanner-unfriendly-api-key-placeholder', pattern: /\byour[_-]?[a-z0-9_-]*key[a-z0-9_-]*\b/i },
+  { label: 'actual-looking-sk-token', pattern: /(?:api[-_\s]?key|token)[^\r\n]{0,80}\bsk-[A-Za-z0-9_-]{8,}\b/i },
+  { label: 'session-id-marker', pattern: new RegExp('session' + '_id') },
 ]
 
 function walk(path: string): string[] {
@@ -172,9 +189,9 @@ for (const file of files) {
   }
 
   const inspect = mode === 'write' ? next : text
-  for (const pattern of forbiddenPatterns) {
+  for (const { label, pattern } of customPublicLeakPatterns) {
     if (pattern.test(inspect)) {
-      findings.push(`${relative(root, file).replace(/\\/g, '/')}: ${pattern}`)
+      findings.push(`${relative(root, file).replace(/\\/g, '/')}: ${label}`)
       break
     }
   }


### PR DESCRIPTION
﻿## Summary
- expand public artifact hygiene coverage to root support/public docs and extension package manifests
- replace raw regex findings with named public leak pattern labels
- add actual-looking GitHub/AWS/Slack/private-key credential pattern coverage
- include extension package manifests in public claim-boundary scanning and tests

## Verification
- bun test scripts/public-artifact-hygiene.test.ts scripts/product-public-claim-boundary.test.ts scripts/public-repo-readiness.test.ts
- bun run product:public-artifact-hygiene
- bun run product:public-claim-boundary:check
- bun run verify:privacy
- bun run typecheck --pretty false
- bun test --max-concurrency=1
- git diff --check

## Claim Boundary
This is current-tree public hygiene and claim-boundary hardening only. It does not claim full-history secret cleanliness, hosted secret scanning status, production readiness, release readiness, or external validation.
