### PR TITLE
Add evidence manifest behavior tests

### DIFF
--- a/scripts/product-evidence-manifest.test.ts
+++ b/scripts/product-evidence-manifest.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildEvidenceManifestJsonl,
+  buildProductEvidenceManifestReport,
+  hasCredentialPattern,
+  roleFor,
+  type EvidenceRecord,
+} from './product-evidence-manifest'
+
+const sha = 'a'.repeat(64)
+
+function record(path: string, role: EvidenceRecord['role'], overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  return {
+    path,
+    role,
+    sha256: sha,
+    sizeBytes: 10,
+    ...overrides,
+  }
+}
+
+function okFor(report: ReturnType<typeof buildProductEvidenceManifestReport>['report'], label: string): boolean {
+  const check = report.evidenceChecks.find((item) => item.label === label)
+  if (!check) throw new Error(`missing check: ${label}`)
+  return check.ok
+}
+
+const completeRecords = [
+  record('package.json', 'source'),
+  record('docs/product-quality/example-report.json', 'evidence_report'),
+  record('reports/openclaude-example.jsonl', 'evidence_artifact'),
+  record('docs/product-quality/product-quality-gate.md', 'quality_gate'),
+  record('.github/workflows/pr-checks.yml', 'workflow'),
+]
+
+describe('product evidence manifest behavior', () => {
+  test('builds a bounded manifest report from concrete records', () => {
+    const { report, manifestText } = buildProductEvidenceManifestReport({
+      evidenceRecords: completeRecords,
+      generatedAt: '2026-06-16T00:00:00.000Z',
+      requiredPaths: completeRecords.map((item) => item.path),
+      recursiveSelfInputs: ['docs/product-quality/product-evidence-manifest.json'],
+    })
+
+    expect(report.generatedAt).toBe('2026-06-16T00:00:00.000Z')
+    expect(report.evidenceRecordCount).toBe(completeRecords.length)
+    expect(report.evidenceTotalSizeBytes).toBe(50)
+    expect(report.evidenceRoles).toEqual({
+      source: 1,
+      evidence_report: 1,
+      evidence_artifact: 1,
+      quality_gate: 1,
+      workflow: 1,
+    })
+    expect(report.providerCallsPerformed).toEqual([])
+    expect(report.externalAttestationGenerated).toBe(false)
+    expect(report.releaseReadinessClaimAllowed).toBe(false)
+    expect(report.evidenceChecks.every((item) => item.ok)).toBe(true)
+    expect(manifestText).toBe(buildEvidenceManifestJsonl(completeRecords))
+  })
+
+  test('fails behavior checks for missing evidence, invalid records, self-input recursion, and credential-shaped paths', () => {
+    const credentialPath = `reports/ghp_${'A'.repeat(30)}.jsonl`
+    const { report } = buildProductEvidenceManifestReport({
+      evidenceRecords: [
+        ...completeRecords,
+        record('docs/product-quality/product-evidence-manifest.json', 'evidence_report'),
+        record(credentialPath, 'evidence_artifact', { sha256: 'not-a-sha', sizeBytes: 0 }),
+      ],
+      requiredPaths: [...completeRecords.map((item) => item.path), 'reports/missing-required.jsonl'],
+      recursiveSelfInputs: ['docs/product-quality/product-evidence-manifest.json'],
+    })
+
+    expect(report.missingRequiredEvidencePaths).toEqual(['reports/missing-required.jsonl'])
+    expect(okFor(report, 'required evidence paths are present')).toBe(false)
+    expect(okFor(report, 'evidence records have SHA-256 digests')).toBe(false)
+    expect(okFor(report, 'evidence records have nonzero sizes')).toBe(false)
+    expect(okFor(report, 'recursive self inputs are excluded')).toBe(false)
+    expect(okFor(report, 'manifest contains no credential patterns')).toBe(false)
+  })
+
+  test('classifies record roles by behavior instead of filename string presence only', () => {
+    expect(roleFor('package.json')).toBe('source')
+    expect(roleFor('bun.lock')).toBe('source')
+    expect(roleFor('.github/workflows/pr-checks.yml')).toBe('workflow')
+    expect(roleFor('docs/product-quality/product-quality-gate.md')).toBe('quality_gate')
+    expect(roleFor('docs/product-quality/example-report.json')).toBe('evidence_report')
+    expect(roleFor('reports/openclaude-example.jsonl')).toBe('evidence_artifact')
+  })
+
+  test('detects credential-shaped values before manifest packaging is treated as clean evidence', () => {
+    expect(hasCredentialPattern(`github_pat_${'A'.repeat(40)}`)).toBe(true)
+    expect(hasCredentialPattern('reports/openclaude-safe-evidence.jsonl')).toBe(false)
+  })
+})

--- a/scripts/product-evidence-manifest.ts
+++ b/scripts/product-evidence-manifest.ts
@@ -3,20 +3,20 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { join, resolve } from 'node:path'
 import { sha256 as sha256Text } from './quality-report-helpers'
 
-type EvidenceCheck = {
+export type EvidenceCheck = {
   label: string
   ok: boolean
   detail: string
 }
 
-type EvidenceRecord = {
+export type EvidenceRecord = {
   path: string
   sha256: string
   sizeBytes: number
   role: 'source' | 'evidence_report' | 'evidence_artifact' | 'quality_gate' | 'workflow'
 }
 
-type ProductEvidenceManifestReport = {
+export type ProductEvidenceManifestReport = {
   generatedAt: string
   mode: 'local_no_provider_product_evidence_manifest'
   manifestFormat: 'openclaude_product_evidence_manifest_v1'
@@ -53,7 +53,7 @@ const root = process.cwd()
 const docsDir = resolve(root, 'docs/product-quality')
 const reportsDir = resolve(root, 'reports')
 const manifestJsonlPath = 'reports/openclaude-product-evidence-manifest.jsonl'
-const selfReportPaths = [
+export const selfReportPaths = [
   'docs/product-quality/product-evidence-manifest.json',
   'docs/product-quality/product-evidence-manifest.md',
   manifestJsonlPath,
@@ -69,7 +69,7 @@ const credentialPatterns = [
   /-----BEGIN (RSA|DSA|EC|OPENSSH|PGP) PRIVATE KEY-----/,
 ]
 
-const requiredEvidencePaths = [
+export const requiredEvidencePaths = [
   'package.json',
   'bun.lock',
   '.jscpd.json',
@@ -228,7 +228,7 @@ function check(label: string, ok: boolean, detail: string): EvidenceCheck {
   return { label, ok, detail }
 }
 
-function hasCredentialPattern(text: string): boolean {
+export function hasCredentialPattern(text: string): boolean {
   return credentialPatterns.some((pattern) => pattern.test(text))
 }
 
@@ -255,7 +255,7 @@ function listFiles(prefix: string): string[] {
   return files.sort((left, right) => left.localeCompare(right))
 }
 
-function roleFor(path: string): EvidenceRecord['role'] {
+export function roleFor(path: string): EvidenceRecord['role'] {
   if (path === 'package.json') return 'source'
   if (path === 'bun.lock') return 'source'
   if (path.startsWith('.github/')) return 'workflow'
@@ -292,7 +292,7 @@ function buildEvidenceRecords(): EvidenceRecord[] {
   })
 }
 
-function countRoles(records: EvidenceRecord[]): Record<EvidenceRecord['role'], number> {
+export function countRoles(records: EvidenceRecord[]): Record<EvidenceRecord['role'], number> {
   return {
     source: records.filter((record) => record.role === 'source').length,
     evidence_report: records.filter((record) => record.role === 'evidence_report').length,
@@ -300,6 +300,92 @@ function countRoles(records: EvidenceRecord[]): Record<EvidenceRecord['role'], n
     quality_gate: records.filter((record) => record.role === 'quality_gate').length,
     workflow: records.filter((record) => record.role === 'workflow').length,
   }
+}
+
+export function buildEvidenceManifestJsonl(evidenceRecords: EvidenceRecord[]): string {
+  return `${evidenceRecords.map((record) => JSON.stringify(record)).join('\n')}\n`
+}
+
+export function buildProductEvidenceManifestReport({
+  evidenceRecords,
+  generatedAt = new Date().toISOString(),
+  requiredPaths = requiredEvidencePaths,
+  recursiveSelfInputs = selfReportPaths,
+  outputManifestJsonlPath = manifestJsonlPath,
+}: {
+  evidenceRecords: EvidenceRecord[]
+  generatedAt?: string
+  requiredPaths?: string[]
+  recursiveSelfInputs?: string[]
+  outputManifestJsonlPath?: string
+}): { report: ProductEvidenceManifestReport, manifestText: string } {
+  const manifestText = buildEvidenceManifestJsonl(evidenceRecords)
+  const manifestJsonlSha256 = sha256Text(manifestText)
+  const missingRequiredEvidencePaths = requiredPaths.filter((path) => !evidenceRecords.some((record) => record.path === path))
+  const evidenceRoles = countRoles(evidenceRecords)
+  const evidenceTotalSizeBytes = evidenceRecords.reduce((total, record) => total + record.sizeBytes, 0)
+  const manifestHasCredentialPattern = hasCredentialPattern(manifestText)
+
+  const evidenceChecks = [
+    check('required evidence paths are present', missingRequiredEvidencePaths.length === 0, missingRequiredEvidencePaths.join(',') || 'all present'),
+    check('evidence records have SHA-256 digests', evidenceRecords.every((record) => /^[a-f0-9]{64}$/.test(record.sha256)), `${evidenceRecords.length} records`),
+    check('evidence records have nonzero sizes', evidenceRecords.every((record) => record.sizeBytes > 0), `${evidenceTotalSizeBytes} total bytes`),
+    check('manifest JSONL has one line per evidence record', manifestText.trim().split(/\r?\n/).length === evidenceRecords.length, `${evidenceRecords.length} lines`),
+    check('manifest JSONL hash is recorded', manifestJsonlSha256.length === 64, outputManifestJsonlPath),
+    check('recursive self inputs are excluded', recursiveSelfInputs.every((path) => !evidenceRecords.some((record) => record.path === path)), recursiveSelfInputs.join(',')),
+    check('evidence roles cover reports, artifacts, workflows, source, and gate', Object.values(evidenceRoles).every((count) => count > 0), JSON.stringify(evidenceRoles)),
+    check('manifest contains no credential patterns', !manifestHasCredentialPattern, 'known key/token/private-key patterns absent'),
+    check('primary source patterns are recorded', true, 'SLSA provenance, in-toto Statement, OpenSSF Scorecard'),
+    check('protected actions are not executed', true, 'protectedActionsExecuted=[]'),
+    check('release and external claims remain blocked', true, 'all claim flags false'),
+  ]
+
+  const report: ProductEvidenceManifestReport = {
+    generatedAt,
+    mode: 'local_no_provider_product_evidence_manifest',
+    manifestFormat: 'openclaude_product_evidence_manifest_v1',
+    primarySourceInputs: [
+      {
+        sourceProject: 'SLSA Build Provenance',
+        sourceUrl: 'https://slsa.dev/spec/v1.2/build-provenance',
+        observedPattern: 'Provenance records identify subjects, build definitions, run details, and dependencies so artifacts can be traced back to how they were produced.',
+      },
+      {
+        sourceProject: 'in-toto Attestation Framework',
+        sourceUrl: 'https://github.com/in-toto/attestation',
+        observedPattern: 'A Statement binds subjects to a typed predicate, making evidence packages machine-checkable instead of narrative-only.',
+      },
+      {
+        sourceProject: 'OpenSSF Scorecard',
+        sourceUrl: 'https://github.com/ossf/scorecard',
+        observedPattern: 'Open-source security posture is stronger when checks, evidence, and remediation boundaries are explicit and repeatable.',
+      },
+    ],
+    manifestJsonlPath: outputManifestJsonlPath,
+    manifestJsonlSha256,
+    evidenceRecordCount: evidenceRecords.length,
+    evidenceTotalSizeBytes,
+    evidenceRoles,
+    requiredEvidencePaths: requiredPaths,
+    missingRequiredEvidencePaths,
+    recursiveSelfInputsExcluded: recursiveSelfInputs,
+    providerCallsPerformed: [],
+    liveModelCallsPerformed: [],
+    externalCallsPerformed: [],
+    protectedActionsExecuted: [],
+    externalAttestationGenerated: false,
+    signedProvenanceGenerated: false,
+    releaseReadinessClaimAllowed: false,
+    productionReadinessClaimAllowed: false,
+    publicReadinessClaimAllowed: false,
+    externalValidationClaimAllowed: false,
+    autonomousReliabilityClaimAllowed: false,
+    evidenceRecords,
+    evidenceChecks,
+    claimBoundary: 'Product evidence manifest is local no-provider evidence packaging only. It is not a signed attestation and does not authorize release, production, public, external-validation, or autonomous-reliability claims.',
+  }
+
+  return { report, manifestText }
 }
 
 function writeMarkdown(report: ProductEvidenceManifestReport): void {
@@ -371,82 +457,18 @@ function main(): void {
   mkdirSync(reportsDir, { recursive: true })
 
   const evidenceRecords = buildEvidenceRecords()
-  const manifestText = evidenceRecords.map((record) => JSON.stringify(record)).join('\n') + '\n'
+  const { report, manifestText } = buildProductEvidenceManifestReport({ evidenceRecords })
   writeFileSync(resolve(root, manifestJsonlPath), manifestText)
-  const manifestJsonlSha256 = sha256Text(manifestText)
-  const missingRequiredEvidencePaths = requiredEvidencePaths.filter((path) => !evidenceRecords.some((record) => record.path === path))
-  const evidenceRoles = countRoles(evidenceRecords)
-  const evidenceTotalSizeBytes = evidenceRecords.reduce((total, record) => total + record.sizeBytes, 0)
-  const manifestHasCredentialPattern = hasCredentialPattern(manifestText)
-
-  const evidenceChecks = [
-    check('required evidence paths are present', missingRequiredEvidencePaths.length === 0, missingRequiredEvidencePaths.join(',') || 'all present'),
-    check('evidence records have SHA-256 digests', evidenceRecords.every((record) => /^[a-f0-9]{64}$/.test(record.sha256)), `${evidenceRecords.length} records`),
-    check('evidence records have nonzero sizes', evidenceRecords.every((record) => record.sizeBytes > 0), `${evidenceTotalSizeBytes} total bytes`),
-    check('manifest JSONL has one line per evidence record', manifestText.trim().split(/\r?\n/).length === evidenceRecords.length, `${evidenceRecords.length} lines`),
-    check('manifest JSONL hash is recorded', manifestJsonlSha256.length === 64, manifestJsonlPath),
-    check('recursive self inputs are excluded', selfReportPaths.every((path) => !evidenceRecords.some((record) => record.path === path)), selfReportPaths.join(',')),
-    check('evidence roles cover reports, artifacts, workflows, source, and gate', Object.values(evidenceRoles).every((count) => count > 0), JSON.stringify(evidenceRoles)),
-    check('manifest contains no credential patterns', !manifestHasCredentialPattern, 'known key/token/private-key patterns absent'),
-    check('primary source patterns are recorded', true, 'SLSA provenance, in-toto Statement, OpenSSF Scorecard'),
-    check('protected actions are not executed', true, 'protectedActionsExecuted=[]'),
-    check('release and external claims remain blocked', true, 'all claim flags false'),
-  ]
-
-  const report: ProductEvidenceManifestReport = {
-    generatedAt: new Date().toISOString(),
-    mode: 'local_no_provider_product_evidence_manifest',
-    manifestFormat: 'openclaude_product_evidence_manifest_v1',
-    primarySourceInputs: [
-      {
-        sourceProject: 'SLSA Build Provenance',
-        sourceUrl: 'https://slsa.dev/spec/v1.2/build-provenance',
-        observedPattern: 'Provenance records identify subjects, build definitions, run details, and dependencies so artifacts can be traced back to how they were produced.',
-      },
-      {
-        sourceProject: 'in-toto Attestation Framework',
-        sourceUrl: 'https://github.com/in-toto/attestation',
-        observedPattern: 'A Statement binds subjects to a typed predicate, making evidence packages machine-checkable instead of narrative-only.',
-      },
-      {
-        sourceProject: 'OpenSSF Scorecard',
-        sourceUrl: 'https://github.com/ossf/scorecard',
-        observedPattern: 'Open-source security posture is stronger when checks, evidence, and remediation boundaries are explicit and repeatable.',
-      },
-    ],
-    manifestJsonlPath,
-    manifestJsonlSha256,
-    evidenceRecordCount: evidenceRecords.length,
-    evidenceTotalSizeBytes,
-    evidenceRoles,
-    requiredEvidencePaths,
-    missingRequiredEvidencePaths,
-    recursiveSelfInputsExcluded: selfReportPaths,
-    providerCallsPerformed: [],
-    liveModelCallsPerformed: [],
-    externalCallsPerformed: [],
-    protectedActionsExecuted: [],
-    externalAttestationGenerated: false,
-    signedProvenanceGenerated: false,
-    releaseReadinessClaimAllowed: false,
-    productionReadinessClaimAllowed: false,
-    publicReadinessClaimAllowed: false,
-    externalValidationClaimAllowed: false,
-    autonomousReliabilityClaimAllowed: false,
-    evidenceRecords,
-    evidenceChecks,
-    claimBoundary: 'Product evidence manifest is local no-provider evidence packaging only. It is not a signed attestation and does not authorize release, production, public, external-validation, or autonomous-reliability claims.',
-  }
 
   writeFileSync(resolve(docsDir, 'product-evidence-manifest.json'), `${JSON.stringify(report, null, 2)}\n`)
   writeMarkdown(report)
 
-  for (const item of evidenceChecks) {
+  for (const item of report.evidenceChecks) {
     console.log(`${item.ok ? 'PASS' : 'FAIL'}: ${item.label} (${item.detail})`)
   }
 
   console.log('')
-  if (!evidenceChecks.every((item) => item.ok)) {
+  if (!report.evidenceChecks.every((item) => item.ok)) {
     console.error('RESULT: FAIL')
     process.exit(1)
   }
@@ -454,7 +476,7 @@ function main(): void {
   console.log('RESULT: PASS')
   console.log(`manifest_jsonl_path=${manifestJsonlPath}`)
   console.log(`evidence_record_count=${evidenceRecords.length}`)
-  console.log(`evidence_total_size_bytes=${evidenceTotalSizeBytes}`)
+  console.log(`evidence_total_size_bytes=${report.evidenceTotalSizeBytes}`)
   console.log(`provider_calls_performed=${report.providerCallsPerformed.length}`)
   console.log(`live_model_calls_performed=${report.liveModelCallsPerformed.length}`)
   console.log(`external_calls_performed=${report.externalCallsPerformed.length}`)
@@ -462,4 +484,6 @@ function main(): void {
   console.log(`release_readiness_claim_allowed=${report.releaseReadinessClaimAllowed}`)
 }
 
-main()
+if (import.meta.main) {
+  main()
+}


### PR DESCRIPTION
## Summary
- split product evidence manifest analysis into exported pure builders so manifest behavior can be tested without writing generated reports
- add behavior tests for happy path, missing evidence, invalid digest/size, recursive self-inputs, credential-shaped paths, role classification, and claim-boundary flags
- keep the existing `product:evidence-manifest` write-mode output path intact

## Verification
- `bun test scripts/product-evidence-manifest.test.ts`
- `bun run product:evidence-manifest`
- `bun run typecheck --pretty false`
- `bun run verify:privacy`
- `bun test --max-concurrency=1`
- `git diff --check`