### PR TITLE
Add hosted trust posture check mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "product:public-claim-boundary:check": "bun scripts/product-public-claim-boundary.ts --check",
     "product:github-remote-surface-audit": "bun run scripts/product-github-remote-surface-audit.ts",
     "product:github-hosted-trust-posture": "bun run scripts/product-github-hosted-trust-posture.ts",
+    "product:github-hosted-trust-posture:check": "bun run scripts/product-github-hosted-trust-posture.ts --check",
     "product:code-scanning-remediation-queue": "bun run scripts/product-code-scanning-remediation-queue.ts",
     "product:protected-action-authorization-packet": "bun run scripts/product-protected-action-authorization-packet.ts",
     "product:evidence-manifest": "bun run scripts/product-evidence-manifest.ts",

--- a/scripts/product-github-hosted-trust-posture.test.ts
+++ b/scripts/product-github-hosted-trust-posture.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
 import {
   analyzeHostedTrustPosture,
   buildHostedTrustPostureJsonl,
+  hostedTrustPostureMode,
 } from './product-github-hosted-trust-posture'
 
 describe('GitHub hosted trust posture analysis', () => {
+  test('supports a read-only check mode command surface', () => {
+    expect(hostedTrustPostureMode(['bun', 'scripts/product-github-hosted-trust-posture.ts', '--check'])).toBe('check')
+    expect(hostedTrustPostureMode(['bun', 'scripts/product-github-hosted-trust-posture.ts'])).toBe('write')
+
+    const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as { scripts: Record<string, string> }
+    expect(pkg.scripts['product:github-hosted-trust-posture:check']).toBe(
+      'bun run scripts/product-github-hosted-trust-posture.ts --check',
+    )
+  })
+
   test('classifies hosted security gaps without enabling readiness claims', () => {
     const report = analyzeHostedTrustPosture({
       repository: 'svy04/metaforge',

--- a/scripts/product-github-hosted-trust-posture.ts
+++ b/scripts/product-github-hosted-trust-posture.ts
@@ -138,6 +138,10 @@ const reportJsonPath = 'docs/product-quality/github-hosted-trust-posture-report.
 const reportMdPath = 'docs/product-quality/github-hosted-trust-posture-report.md'
 const reportJsonlPath = 'reports/openclaude-github-hosted-trust-posture.jsonl'
 
+export function hostedTrustPostureMode(args = process.argv): 'check' | 'write' {
+  return args.includes('--check') ? 'check' : 'write'
+}
+
 function sha256(input: string | Buffer): string {
   return createHash('sha256').update(input).digest('hex')
 }
@@ -602,6 +606,7 @@ function writeReports(report: HostedTrustPostureReport): void {
 }
 
 function main(): void {
+  const mode = hostedTrustPostureMode()
   const repo = discoverRepository()
   const security = readRepositorySecurity(repo.repository)
   const branch = readBranchProtection(repo.repository, repo.defaultBranch)
@@ -630,12 +635,15 @@ function main(): void {
     },
   })
 
-  writeReports(report)
+  if (mode === 'write') {
+    writeReports(report)
+  }
 
   for (const item of report.evidenceChecks) {
     console.log(`${item.ok ? 'PASS' : 'FAIL'}: ${item.label} (${item.detail})`)
   }
   console.log(`RESULT: ${report.status === 'hosted_trust_risks_detected' ? 'RISKS_RECORDED' : 'PASS'}`)
+  console.log(`mode=${mode}`)
   console.log(`repository=${report.repository}`)
   console.log(`risk_count=${report.riskCount}`)
   console.log(`code_scanning_open_alert_count=${report.codeScanning.openAlertCount}`)


### PR DESCRIPTION
## Summary
- add a read-only product:github-hosted-trust-posture:check command
- keep the existing write-mode hosted trust posture report generation unchanged
- cover the check-mode command surface with a Bun test

## Verification
- bun test scripts/product-github-hosted-trust-posture.test.ts
- bun run product:github-hosted-trust-posture:check
- bun run typecheck --pretty false
- bun run verify:privacy
- bun run build
- git diff --check

## Claim boundary
The check command records hosted GitHub risks without writing report artifacts or unlocking security, release, production, external-validation, or autonomous-reliability claims. Current live check still records hosted trust risks (isk_count=8, code_scanning_open_alert_count=433).