### PR TITLE
[codex] Harden public workspace path hygiene

### DIFF
--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -66,6 +66,24 @@ describe('public artifact hygiene scanner', () => {
     expect(`${result.stdout}\n${result.stderr}`).toContain('README.md')
   })
 
+  test('rejects environment-expanded user workspace paths in public docs', () => {
+    const repo = makeTempRepo()
+    writeFileSync(
+      join(repo, 'README.md'),
+      [
+        String.raw`Internal capture: %USERPROFILE%\Desktop\client-lab\trace.json`,
+        String.raw`Local proof: $HOME/Documents/private-research/session.md`,
+        String.raw`Operator note: ~/Desktop/private-run/output.log`,
+      ].join('\n'),
+    )
+
+    const result = runHygiene(repo)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('README.md')
+    expect(`${result.stdout}\n${result.stderr}`).toContain('user-workspace-path')
+  })
+
   test('rejects pasted internal runtime context in public docs', () => {
     const repo = makeTempRepo()
     writeFileSync(

--- a/scripts/public-artifact-hygiene.ts
+++ b/scripts/public-artifact-hygiene.ts
@@ -129,6 +129,7 @@ const customPublicLeakPatterns: PublicLeakPattern[] = [
   { label: 'windows-user-path', pattern: /C:(?:\\{1,2}|\/)Users(?:\\{1,2}|\/)[^\\/\s"']+/ },
   { label: 'posix-user-path', pattern: /\/Users\/[^/\s"']+/ },
   { label: 'relative-user-path', pattern: /Users\/[^/\s"']+/ },
+  { label: 'user-workspace-path', pattern: /(?:%USERPROFILE%|\$HOME|\$\{HOME\}|~)(?:\\+|\/)(?:Desktop|Documents)(?:\\+|\/)[^\r\n`"']+/i },
   { label: 'private-workspace-korean-name', pattern: new RegExp(String.raw`\uB0B4\u0020\uC21C\uC218\u0020\uC7AC\uBBF8`) },
   { label: 'private-workspace-name', pattern: new RegExp('Digital ' + 'Factory') },
   { label: 'codex-memory-path', pattern: new RegExp(String.raw`\.` + 'codex' + String.raw`[\\/]+` + 'memories', 'i') },


### PR DESCRIPTION
## What changed

- Added public hygiene coverage for environment-expanded user workspace paths:
  - `%USERPROFILE%\Desktop\...`
  - `$HOME/Documents/...`
  - `~/Desktop/...`
- Kept the detector scoped to `Desktop` and `Documents` workspace leaks so ordinary setup references like `~/.claude/settings.json` remain allowed.

## Why

The public feedback specifically called out local folder leakage as a trust issue. GitHub's push-protection and sensitive-data guidance favor blocking sensitive material before it reaches the remote, while OWASP secrets guidance reinforces keeping sensitive configuration out of source control. This patch improves the local pre-push hygiene surface without claiming full-history secret cleanliness or hosted secret-scanning coverage.

Primary sources used:

- GitHub Push Protection: https://docs.github.com/en/code-security/concepts/secret-security/push-protection
- GitHub Removing Sensitive Data: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository
- OWASP Secrets Management Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html

## Validation

- RED: `bun test scripts/public-artifact-hygiene.test.ts` failed because the scanner allowed `%USERPROFILE%`, `$HOME`, and `~` workspace paths.
- GREEN: `bun test scripts/public-artifact-hygiene.test.ts`
- `bun run scripts/public-artifact-hygiene.ts`
- `bun test scripts/public-repo-readiness.test.ts`
- `bun run build`
- `bun run verify:privacy`
- `git diff --check`

## Claim boundary

This is current-tree local hygiene evidence only. It does not prove full Git history secret cleanliness, GitHub secret-scanning alert status, release readiness, production readiness, or external validation.