### PR TITLE
[codex] Fix JSONL file handle race

### DIFF
--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { parseJSONL, readJSONLFile } from './json'
+
+const tempDirs: string[] = []
+const TEST_MAX_JSONL_READ_BYTES = 100 * 1024 * 1024
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('JSONL utilities', () => {
+  test('parseJSONL skips malformed and empty lines', () => {
+    const rows = parseJSONL<{ id: number }>(
+      [
+        '{"id":1}',
+        '',
+        'not-json',
+        '{"id":2}',
+      ].join('\n'),
+    )
+
+    expect(rows).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  test('readJSONLFile reads through one file handle and skips malformed lines', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openclaude-jsonl-'))
+    tempDirs.push(dir)
+    const filePath = join(dir, 'events.jsonl')
+    await writeFile(
+      filePath,
+      [
+        '{"kind":"ok","value":1}',
+        'malformed',
+        '{"kind":"ok","value":2}',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const rows = await readJSONLFile<{ kind: string; value: number }>(filePath)
+
+    expect(rows).toEqual([
+      { kind: 'ok', value: 1 },
+      { kind: 'ok', value: 2 },
+    ])
+  })
+
+  test('readJSONLFile reads only the tail of large files and skips the first partial line', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openclaude-jsonl-tail-'))
+    tempDirs.push(dir)
+    const filePath = join(dir, 'large-events.jsonl')
+    const tail = [
+      'partial-prefix-without-json-ending',
+      '{"kind":"tail","value":1}',
+      'malformed',
+      '{"kind":"tail","value":2}',
+      '',
+    ].join('\n')
+    const tailBytes = Buffer.from(tail)
+
+    const fd = await open(filePath, 'w')
+    try {
+      await fd.truncate(TEST_MAX_JSONL_READ_BYTES + tailBytes.length)
+      await fd.write(tailBytes, 0, tailBytes.length, TEST_MAX_JSONL_READ_BYTES)
+    } finally {
+      await fd.close()
+    }
+
+    const rows = await readJSONLFile<{ kind: string; value: number }>(filePath)
+
+    expect(rows).toEqual([
+      { kind: 'tail', value: 1 },
+      { kind: 'tail', value: 2 },
+    ])
+  })
+})

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,4 +1,4 @@
-import { open, readFile, stat } from 'fs/promises'
+import { open } from 'fs/promises'
 import {
   applyEdits,
   modify,
@@ -199,11 +199,11 @@ const MAX_JSONL_READ_BYTES = 100 * 1024 * 1024
  * is ~2M tokens, which is well under 100 MB of JSONL.
  */
 export async function readJSONLFile<T>(filePath: string): Promise<T[]> {
-  const { size } = await stat(filePath)
-  if (size <= MAX_JSONL_READ_BYTES) {
-    return parseJSONL<T>(await readFile(filePath))
-  }
   await using fd = await open(filePath, 'r')
+  const { size } = await fd.stat()
+  if (size <= MAX_JSONL_READ_BYTES) {
+    return parseJSONL<T>(await fd.readFile())
+  }
   const buf = Buffer.allocUnsafe(MAX_JSONL_READ_BYTES)
   let totalRead = 0
   const fileOffset = size - MAX_JSONL_READ_BYTES


### PR DESCRIPTION
## What changed

- Updated `readJSONLFile` to open the JSONL file once and use the same `FileHandle` for `stat`, small-file `readFile`, and large-file tail reads.
- Added focused JSONL tests for malformed-line skipping and the large-file tail-read path.

## Why

CodeQL currently reports two `js/file-system-race` alerts in `src/utils/json.ts` (#49 and #50). The old implementation checked file size with path-based `stat(filePath)`, then used path-based `readFile(filePath)` or `open(filePath)` later. That is the TOCTOU shape CodeQL flags. This patch follows CodeQL's recommended descriptor/handle pattern and the local `readFileInRange` pattern.

## Validation

- `bun test src\utils\json.test.ts`
- `bun test src\utils\json.test.ts src\utils\readFileInRange.test.ts`
- `bun run typecheck --pretty false`
- `bun run verify:privacy`
- `bun run build`
- `git diff --check`

Claim boundary: this is a targeted local code fix for the two JSONL file-race alerts. Alert closure still requires hosted CodeQL to analyze the pushed commit.