### PR TITLE
[codex] Fix git file race alerts

### DIFF
--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
+import { execFileNoThrowWithCwd } from './execFileNoThrow.js'
+
+const tempDirs: string[] = []
+const execFileAsync = promisify(execFile)
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+describe('git issue state preservation', () => {
+  test('captures untracked text files through the issue preserve path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openclaude-git-state-'))
+    tempDirs.push(dir)
+
+    const init = await execFileNoThrowWithCwd('git', ['init'], {
+      cwd: dir,
+      preserveOutputOnError: false,
+    })
+    expect(init.code).toBe(0)
+
+    await writeFile(join(dir, 'note.txt'), 'hello from an untracked file', 'utf8')
+
+    const gitModuleUrl = pathToFileURL(join(import.meta.dir, 'git.ts')).href
+    const script = `
+      const { preserveGitStateForIssue } = await import(${JSON.stringify(gitModuleUrl)});
+      const state = await preserveGitStateForIssue();
+      console.log(JSON.stringify(state?.untracked_files ?? null));
+    `
+    const { stdout } = await execFileAsync(process.execPath, ['-e', script], {
+      cwd: dir,
+      encoding: 'utf8',
+    })
+
+    expect(JSON.parse(stdout.trim())).toEqual([
+      {
+        path: 'note.txt',
+        content: 'hello from an untracked file',
+      },
+    ])
+  })
+})

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto'
 import { readFileSync, realpathSync, statSync } from 'fs'
-import { open, readFile, realpath, stat } from 'fs/promises'
+import { open, realpath } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { basename, dirname, join, resolve, sep } from 'path'
 import { hasBinaryExtension, isBinaryContent } from '../constants/files.js'
@@ -646,39 +646,43 @@ async function captureUntrackedFiles(): Promise<
     }
 
     try {
-      const stats = await stat(filePath)
-      const fileSize = stats.size
-
-      // Skip files exceeding per-file limit
-      if (fileSize > MAX_FILE_SIZE_BYTES) {
-        logForDebugging(
-          `Untracked file capture: skipping ${filePath} (exceeds ${MAX_FILE_SIZE_BYTES} bytes)`,
-        )
-        continue
-      }
-
-      // Check total size limit
-      if (totalSize + fileSize > MAX_TOTAL_SIZE_BYTES) {
-        logForDebugging(
-          `Untracked file capture: reached total size limit (${MAX_TOTAL_SIZE_BYTES} bytes)`,
-        )
-        break
-      }
-
-      // Empty file - no need to open
-      if (fileSize === 0) {
-        result.push({ path: filePath, content: '' })
-        continue
-      }
-
-      // Binary sniff on up to SNIFF_BUFFER_SIZE bytes. Caps binary-file reads
-      // at SNIFF_BUFFER_SIZE even though MAX_FILE_SIZE_BYTES allows up to 500MB.
-      // If the file fits in the sniff buffer we reuse it as the content; for
-      // larger text files we fall back to readFile with encoding so the runtime
-      // decodes to a string without materializing a full-size Buffer in JS.
-      const sniffSize = Math.min(SNIFF_BUFFER_SIZE, fileSize)
       const fd = await open(filePath, 'r')
       try {
+        const stats = await fd.stat()
+        if (!stats.isFile()) {
+          continue
+        }
+
+        const fileSize = stats.size
+
+        // Skip files exceeding per-file limit
+        if (fileSize > MAX_FILE_SIZE_BYTES) {
+          logForDebugging(
+            `Untracked file capture: skipping ${filePath} (exceeds ${MAX_FILE_SIZE_BYTES} bytes)`,
+          )
+          continue
+        }
+
+        // Check total size limit
+        if (totalSize + fileSize > MAX_TOTAL_SIZE_BYTES) {
+          logForDebugging(
+            `Untracked file capture: reached total size limit (${MAX_TOTAL_SIZE_BYTES} bytes)`,
+          )
+          break
+        }
+
+        // Empty file - no need to open
+        if (fileSize === 0) {
+          result.push({ path: filePath, content: '' })
+          continue
+        }
+
+        // Binary sniff on up to SNIFF_BUFFER_SIZE bytes. Caps binary-file reads
+        // at SNIFF_BUFFER_SIZE even though MAX_FILE_SIZE_BYTES allows up to 500MB.
+        // If the file fits in the sniff buffer we reuse it as the content; for
+        // larger text files we fall back to readFile with encoding so the runtime
+        // decodes to a string without materializing a full-size Buffer in JS.
+        const sniffSize = Math.min(SNIFF_BUFFER_SIZE, fileSize)
         const sniffBuf = Buffer.alloc(sniffSize)
         const { bytesRead } = await fd.read(sniffBuf, 0, sniffSize, 0)
         const sniff = sniffBuf.subarray(0, bytesRead)
@@ -692,10 +696,9 @@ async function captureUntrackedFiles(): Promise<
           // Sniff already covers the whole file
           content = sniff.toString('utf-8')
         } else {
-          // readFile with encoding decodes to string directly, avoiding a
-          // full-size Buffer living alongside the decoded string. The extra
-          // open/close is cheaper than doubling peak memory for large files.
-          content = await readFile(filePath, 'utf-8')
+          // FileHandle.readFile with encoding decodes to string directly,
+          // avoiding a full-size Buffer living alongside the decoded string.
+          content = await fd.readFile({ encoding: 'utf-8' })
         }
 
         result.push({ path: filePath, content })

--- a/src/utils/git/gitFilesystem.test.ts
+++ b/src/utils/git/gitFilesystem.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { clearResolveGitDirCache, resolveGitDir } from './gitFilesystem.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  clearResolveGitDirCache()
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+describe('resolveGitDir', () => {
+  test('returns the regular .git directory', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openclaude-git-fs-'))
+    tempDirs.push(dir)
+    await mkdir(join(dir, '.git'))
+
+    await expect(resolveGitDir(dir)).resolves.toBe(join(dir, '.git'))
+  })
+
+  test('resolves a worktree .git file pointer', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openclaude-git-worktree-'))
+    tempDirs.push(dir)
+    const actualGitDir = resolve(dir, 'actual.git')
+    await mkdir(actualGitDir)
+    await writeFile(join(dir, '.git'), 'gitdir: actual.git\n', 'utf8')
+
+    await expect(resolveGitDir(dir)).resolves.toBe(actualGitDir)
+  })
+})

--- a/src/utils/git/gitFilesystem.ts
+++ b/src/utils/git/gitFilesystem.ts
@@ -13,7 +13,7 @@
  */
 
 import { unwatchFile, watchFile } from 'fs'
-import { readdir, readFile, stat } from 'fs/promises'
+import { open, readdir, readFile, stat } from 'fs/promises'
 import { join, resolve } from 'path'
 import { waitForScrollIdle } from '../../bootstrap/state.js'
 import { registerCleanup } from '../cleanupRegistry.js'
@@ -54,21 +54,27 @@ export async function resolveGitDir(
 
   const gitPath = join(root, '.git')
   try {
-    const st = await stat(gitPath)
-    if (st.isFile()) {
-      // Worktree or submodule: .git is a file with `gitdir: <path>`
-      // Git strips trailing \n and \r (setup.c read_gitfile_gently).
-      const content = (await readFile(gitPath, 'utf-8')).trim()
-      if (content.startsWith('gitdir:')) {
-        const rawDir = content.slice('gitdir:'.length).trim()
-        const resolved = resolve(root, rawDir)
-        resolveGitDirCache.set(cwd, resolved)
-        return resolved
+    const fd = await open(gitPath, 'r')
+    try {
+      const st = await fd.stat()
+      if (st.isFile()) {
+        // Worktree or submodule: .git is a file with `gitdir: <path>`
+        // Git strips trailing \n and \r (setup.c read_gitfile_gently).
+        const content = (await fd.readFile({ encoding: 'utf-8' })).trim()
+        if (content.startsWith('gitdir:')) {
+          const rawDir = content.slice('gitdir:'.length).trim()
+          const resolved = resolve(root, rawDir)
+          resolveGitDirCache.set(cwd, resolved)
+          return resolved
+        }
       }
+
+      // Regular repo: .git is a directory
+      resolveGitDirCache.set(cwd, gitPath)
+      return gitPath
+    } finally {
+      await fd.close()
     }
-    // Regular repo: .git is a directory
-    resolveGitDirCache.set(cwd, gitPath)
-    return gitPath
   } catch {
     resolveGitDirCache.set(cwd, null)
     return null


### PR DESCRIPTION
## What changed

- Reworked untracked file capture to open each file once, then use the same `FileHandle` for `stat`, binary sniffing, and full text reads.
- Reworked `.git` directory resolution to open `.git` once and read worktree/submodule pointers through the same handle.
- Added focused regression coverage for issue-state untracked file capture and `.git` directory/file pointer resolution.

## Why

GitHub CodeQL reports `js/file-system-race` alerts for path-based check-then-use patterns in the git utilities. This patch follows the CodeQL/Node-safe descriptor pattern locally; hosted CodeQL is still the closure gate for alerts #46, #47, and #48.

## Validation

- `bun test src\utils\git.test.ts src\utils\git\gitFilesystem.test.ts`
- `bun run typecheck --pretty false`
- `bun run verify:privacy`
- `bun run build`
- `bun run product:quality` (exit 0; preserved existing local VS Code CLI unavailable boundary in generated report output)
- `git diff --check`