### PR TITLE
[codex] Fix model cache file race alerts

### DIFF
--- a/src/utils/model/modelCache.test.ts
+++ b/src/utils/model/modelCache.test.ts
@@ -1,30 +1,170 @@
-import { describe, expect, it, beforeEach, afterEach, vi } from 'bun:test'
-import { isModelCacheValid, getCachedModelsFromDisk, saveModelsToCache } from '../model/modelCache.js'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 
-vi.mock('../model/ollamaModels.js', () => ({
-  isOllamaProvider: vi.fn(() => true),
-}))
+const execFileAsync = promisify(execFile)
+const tempDirs: string[] = []
+const MODEL_CACHE_MODULE_URL = pathToFileURL(join(import.meta.dir, 'modelCache.ts')).href
+const PROVIDER_ENV_KEYS = [
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'NVIDIA_NIM',
+  'MINIMAX_API_KEY',
+  'OPENAI_MODEL',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
+] as const
+
+type ProviderMode = 'openai' | 'firstParty'
+
+function childEnv(tempHomeDir: string, mode: ProviderMode): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: tempHomeDir,
+    USERPROFILE: tempHomeDir,
+  }
+  for (const key of PROVIDER_ENV_KEYS) {
+    delete env[key]
+  }
+  if (mode === 'openai') {
+    env.CLAUDE_CODE_USE_OPENAI = '1'
+  }
+  return env
+}
+
+async function runModelCacheScript<T>(
+  tempHomeDir: string,
+  body: string,
+  mode: ProviderMode = 'openai',
+): Promise<T> {
+  const script = `
+    const mod = await import(${JSON.stringify(MODEL_CACHE_MODULE_URL)});
+    ${body}
+  `
+  const { stdout } = await execFileAsync(process.execPath, ['-e', script], {
+    cwd: join(import.meta.dir, '..', '..', '..'),
+    encoding: 'utf8',
+    env: childEnv(tempHomeDir, mode),
+  })
+
+  return JSON.parse(stdout.trim()) as T
+}
+
+async function makeTempHome(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-model-cache-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
 
 describe('modelCache', () => {
-  const mockModel = { value: 'llama3', label: 'Llama 3', description: 'Test model' }
+  const mockModel = {
+    value: 'gpt-test',
+    label: 'GPT Test',
+    description: 'Test model',
+  }
 
-  describe('isModelCacheValid', () => {
-    it('returns false for non-existent cache', async () => {
-      const result = await isModelCacheValid('ollama')
-      expect(result).toBe(false)
-    })
+  test('missing caches are invalid without creating the cache directory', async () => {
+    const tempHomeDir = await makeTempHome()
+
+    const result = await runModelCacheScript<{ valid: boolean }>(
+      tempHomeDir,
+      `
+        const valid = await mod.isModelCacheValid('openai');
+        console.log(JSON.stringify({ valid }));
+      `,
+    )
+
+    expect(result.valid).toBe(false)
+    expect(existsSync(join(tempHomeDir, '.openclaude-model-cache'))).toBe(false)
   })
 
-  describe('getCachedModelsFromDisk', () => {
-    it('returns null when not cache available', async () => {
-      const result = await getCachedModelsFromDisk()
-      expect(result).toBeNull()
-    })
+  test('saveModelsToCache creates the directory and cached models read back', async () => {
+    const tempHomeDir = await makeTempHome()
+
+    const result = await runModelCacheScript<{
+      valid: boolean
+      models: unknown
+      info: { provider: string } | null
+    }>(
+      tempHomeDir,
+      `
+        const models = ${JSON.stringify([mockModel])};
+        await mod.saveModelsToCache(models);
+        const valid = await mod.isModelCacheValid('openai');
+        const cached = await mod.getCachedModelsFromDisk();
+        const info = await mod.getModelCacheInfo();
+        console.log(JSON.stringify({ valid, models: cached, info }));
+      `,
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.models).toEqual([mockModel])
+    expect(result.info).toMatchObject({ provider: 'openai' })
+
+    const cachePath = join(tempHomeDir, '.openclaude-model-cache', 'openai.json')
+    const cache = JSON.parse(await readFile(cachePath, 'utf8'))
+    expect(cache.models).toEqual([mockModel])
   })
 
-  describe('saveModelsToCache', () => {
-    it('has saveModelsToCache function', () => {
-      expect(typeof saveModelsToCache).toBe('function')
-    })
+  test('stale cache files are rejected by disk reads', async () => {
+    const tempHomeDir = await makeTempHome()
+    const cacheDir = join(tempHomeDir, '.openclaude-model-cache')
+    await mkdir(cacheDir, { recursive: true })
+    await writeFile(
+      join(cacheDir, 'openai.json'),
+      JSON.stringify({
+        version: '1',
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+        provider: 'openai',
+        models: [mockModel],
+      }),
+      'utf8',
+    )
+
+    const result = await runModelCacheScript<{
+      valid: boolean
+      models: unknown
+    }>(
+      tempHomeDir,
+      `
+        const valid = await mod.isModelCacheValid('openai');
+        const models = await mod.getCachedModelsFromDisk();
+        console.log(JSON.stringify({ valid, models }));
+      `,
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.models).toBeNull()
+  })
+
+  test('providers without cache support still return null from disk reads', async () => {
+    const tempHomeDir = await makeTempHome()
+
+    const result = await runModelCacheScript<{ models: unknown }>(
+      tempHomeDir,
+      `
+        const models = await mod.getCachedModelsFromDisk();
+        console.log(JSON.stringify({ models }));
+      `,
+      'firstParty',
+    )
+
+    expect(result.models).toBeNull()
   })
 })

--- a/src/utils/model/modelCache.ts
+++ b/src/utils/model/modelCache.ts
@@ -5,8 +5,7 @@
  * Uses async fs operations to avoid blocking the event loop.
  */
 
-import { access, readFile, writeFile, mkdir, unlink } from 'node:fs/promises'
-import { existsSync } from 'node:fs'
+import { readFile, writeFile, mkdir, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { getAPIProvider } from './providers.js'
@@ -23,16 +22,31 @@ interface ModelCache {
 }
 
 function getCacheDir(): string {
-  const home = homedir()
-  const cacheDir = join(home, CACHE_DIR_NAME)
-  if (!existsSync(cacheDir)) {
-    mkdir(cacheDir, { recursive: true })
-  }
-  return cacheDir
+  return join(homedir(), CACHE_DIR_NAME)
 }
 
 function getCacheFilePath(provider: string): string {
   return join(getCacheDir(), `${provider}.json`)
+}
+
+async function readModelCache(provider: string): Promise<ModelCache | null> {
+  try {
+    return JSON.parse(await readFile(getCacheFilePath(provider), 'utf-8')) as ModelCache
+  } catch {
+    return null
+  }
+}
+
+function isFreshModelCache(data: ModelCache, provider: string): boolean {
+  if (data.version !== CACHE_VERSION) {
+    return false
+  }
+  if (data.provider !== provider) {
+    return false
+  }
+
+  const ageHours = (Date.now() - data.timestamp) / (1000 * 60 * 60)
+  return ageHours < CACHE_TTL_HOURS
 }
 
 function isOpenAICompatibleProvider(): boolean {
@@ -41,28 +55,8 @@ function isOpenAICompatibleProvider(): boolean {
 }
 
 export async function isModelCacheValid(provider: string): Promise<boolean> {
-  const cachePath = getCacheFilePath(provider)
-  
-  try {
-    await access(cachePath)
-  } catch {
-    return false
-  }
-
-  try {
-    const data = JSON.parse(await readFile(cachePath, 'utf-8')) as ModelCache
-    if (data.version !== CACHE_VERSION) {
-      return false
-    }
-    if (data.provider !== provider) {
-      return false
-    }
-
-    const ageHours = (Date.now() - data.timestamp) / (1000 * 60 * 60)
-    return ageHours < CACHE_TTL_HOURS
-  } catch {
-    return false
-  }
+  const data = await readModelCache(provider)
+  return data !== null && isFreshModelCache(data, provider)
 }
 
 export async function getCachedModelsFromDisk<T>(): Promise<T[] | null> {
@@ -76,18 +70,12 @@ export async function getCachedModelsFromDisk<T>(): Promise<T[] | null> {
     return null
   }
 
-  const cachePath = getCacheFilePath(provider)
-  
-  if (!(await isModelCacheValid(provider))) {
+  const data = await readModelCache(provider)
+  if (!data || !isFreshModelCache(data, provider)) {
     return null
   }
 
-  try {
-    const data = JSON.parse(await readFile(cachePath, 'utf-8')) as ModelCache
-    return data.models as T[]
-  } catch {
-    return null
-  }
+  return data.models as T[]
 }
 
 export async function saveModelsToCache(
@@ -105,6 +93,7 @@ export async function saveModelsToCache(
   }
   
   try {
+    await mkdir(getCacheDir(), { recursive: true })
     await writeFile(cachePath, JSON.stringify(cacheData, null, 2), 'utf-8')
   } catch (error) {
     console.warn('[ModelCache] Failed to save cache:', error)
@@ -133,26 +122,19 @@ export async function clearModelCache(provider?: string): Promise<void> {
 
 export async function getModelCacheInfo(): Promise<{ provider: string; age: string } | null> {
   const provider = getAPIProvider()
-  const cachePath = getCacheFilePath(provider)
-  
-  try {
-    await access(cachePath)
-  } catch {
+  const data = await readModelCache(provider)
+
+  if (!data) {
     return null
   }
 
-  try {
-    const data = JSON.parse(await readFile(cachePath, 'utf-8')) as ModelCache
-    const ageMs = Date.now() - data.timestamp
-    const ageHours = Math.floor(ageMs / (1000 * 60 * 60))
-    const ageMins = Math.floor((ageMs % (1000 * 60 * 60)) / (1000 * 60))
-    
-    return {
-      provider: data.provider,
-      age: ageHours > 0 ? `${ageHours}h ${ageMins}m` : `${ageMins}m`,
-    }
-  } catch {
-    return null
+  const ageMs = Date.now() - data.timestamp
+  const ageHours = Math.floor(ageMs / (1000 * 60 * 60))
+  const ageMins = Math.floor((ageMs % (1000 * 60 * 60)) / (1000 * 60))
+
+  return {
+    provider: data.provider,
+    age: ageHours > 0 ? `${ageHours}h ${ageMins}m` : `${ageMins}m`,
   }
 }
 


### PR DESCRIPTION
## What changed

- Replaced model-cache `access()` pre-checks with a single `readModelCache()` read/parse helper.
- Reused the parsed cache object for validity checks, disk reads, and cache info instead of checking the path and then reading it later.
- Moved cache directory creation to the write path and awaited `mkdir()` before saving.
- Expanded model cache tests with isolated temp-home coverage for missing, saved, stale, and unsupported-provider cache behavior.

## Why

GitHub CodeQL reports `js/file-system-race` alerts for model cache path existence checks followed by `readFile()` calls. This patch removes those check-then-read paths locally; hosted CodeQL on the default branch remains the closure gate for alerts #51 and #52.

## Validation

- `bun test src\utils\model\modelCache.test.ts`
- `bun run typecheck --pretty false`
- `bun run verify:privacy`
- `bun run build`
- `bun run product:quality` (exit 0; preserved existing local VS Code CLI unavailable boundary in generated report output)
- `git diff --check`