### PR TITLE
[codex] Fix bash parser null check alerts

### DIFF
--- a/src/utils/bash/bashParser.ts
+++ b/src/utils/bash/bashParser.ts
@@ -41,7 +41,7 @@ export function ensureParserInitialized(): Promise<void> {
 }
 
 /** Always succeeds — pure-TS needs no init. */
-export function getParserModule(): ParserModule | null {
+export function getParserModule(): ParserModule {
   return MODULE
 }
 

--- a/src/utils/bash/parser.ts
+++ b/src/utils/bash/parser.ts
@@ -65,8 +65,7 @@ export async function parseCommand(
   if (feature('TREE_SITTER_BASH')) {
     await ensureParserInitialized()
     const mod = getParserModule()
-    logLoadOnce(mod !== null)
-    if (!mod) return null
+    logLoadOnce(true)
 
     try {
       const rootNode = mod.parse(command)
@@ -98,7 +97,7 @@ export const PARSE_ABORTED = Symbol('parse-aborted')
  *
  * Returns:
  *   - Node: parse succeeded
- *   - null: module not loaded / feature off / empty / over-length
+ *   - null: feature off / empty / over-length
  *   - PARSE_ABORTED: module loaded but parse failed (timeout/panic)
  */
 export async function parseCommandRaw(
@@ -108,8 +107,7 @@ export async function parseCommandRaw(
   if (feature('TREE_SITTER_BASH') || feature('TREE_SITTER_BASH_SHADOW')) {
     await ensureParserInitialized()
     const mod = getParserModule()
-    logLoadOnce(mod !== null)
-    if (!mod) return null
+    logLoadOnce(true)
     try {
       const result = mod.parse(command)
       // SECURITY: Module loaded; null here = timeout/node-budget abort in


### PR DESCRIPTION
## Summary
- make the pure-TypeScript bash parser module contract non-null
- remove stale null fallback checks from parser call sites
- keep feature-flag-off behavior returning `null`

## Why
CodeQL flagged the old `mod !== null` comparisons as incompatible-type checks because the current pure-TS parser module always exists when the feature-gated path is entered.

## Verification
- `bun run typecheck --pretty false`
- `bun test src\tools\BashTool\bashPermissions.test.ts src\tools\BashTool\shouldUseSandbox.test.ts src\tools\BashTool\modeValidation.test.ts src\tools\BashTool\sedEditParser.test.ts`
- `git diff --check`