### PR TITLE
[codex] Fix UI comparison alerts

### DIFF
--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
@@ -364,7 +364,7 @@ export function ExitPlanModePermissionRequest({
       // Set initial message - REPL will handle context clear and fresh query
       // Add verification instruction if the feature is enabled
       // Dead code elimination: CLAUDE_CODE_VERIFY_PLAN='false' in external builds, so === 'true' check allows Bun to eliminate the string
-      const verificationInstruction = undefined === 'true' ? `\n\nIMPORTANT: When you have finished implementing the plan, you MUST call the "VerifyPlanExecution" tool directly (NOT the ${AGENT_TOOL_NAME} tool or an agent) to trigger background verification.` : '';
+      const verificationInstruction = process.env.CLAUDE_CODE_VERIFY_PLAN === 'true' ? `\n\nIMPORTANT: When you have finished implementing the plan, you MUST call the "VerifyPlanExecution" tool directly (NOT the ${AGENT_TOOL_NAME} tool or an agent) to trigger background verification.` : '';
 
       // Capture the transcript path before context is cleared (session ID will be regenerated)
       const transcriptPath = getTranscriptPath();

--- a/src/ink/useTerminalNotification.ts
+++ b/src/ink/useTerminalNotification.ts
@@ -111,9 +111,6 @@ export function useTerminalNotification(): TerminalNotification {
             ),
           )
           break
-        case null:
-          // Handled by the if guard above
-          break
       }
     },
     [writeRaw],


### PR DESCRIPTION
## Summary
- remove unreachable `case null` from terminal progress handling
- restore the plan verification instruction check to the actual `CLAUDE_CODE_VERIFY_PLAN` env flag

## Why
CodeQL flagged both sites as incompatible-type comparisons. The progress null path is already handled before the switch, and the plan verification branch should read the runtime/build env flag instead of comparing a literal `undefined`.

## Verification
- `bun run typecheck --pretty false`
- `bun run smoke`
- `git diff --check`