### PR TITLE
[codex] Harden public trust follow-up gates

### DIFF
--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -20,19 +20,25 @@ Consequence:
 
 - Current docs now use MFH as the canonical concrete component and treat `mth` as an unresolved alias/spelling unless the owner defines it separately.
 
-## D-002 - Treat existing `.planning/` and `src/services/orchestra/` as operative evidence
+## D-002 - Treat legacy planning artifacts and `src/services/orchestra/` as operative evidence
 
 Date: 2026-05-10
-Status: accepted
+Status: superseded public-surface wording
 
 Decision:
 
-The planning package treats `.planning/PROJECT.md`, `.planning/ROADMAP.md`, `.planning/phase-*`, and `src/services/orchestra/` as the current source of truth for Orchestra OS status.
+The initial planning package imported legacy planning artifacts and
+`src/services/orchestra/` as evidence that Orchestra OS was not starting from
+zero. The tracked public checkout no longer treats the removed planning
+artifacts as current authority; current public authority lives in `docs/`,
+`src/services/orchestra/`, and generated product-quality evidence.
 
 Evidence:
 
-- `.planning/PROJECT.md` contains detailed v0.2 role, milestone, and validation state.
+- Legacy planning artifacts contained detailed v0.2 role, milestone, and validation state before public hygiene cleanup.
 - `src/services/orchestra/` contains tests and implementations for multiple planned roles.
+- PR #92 removed tracked planning artifacts from the public checkout and added
+  hygiene gates so public docs cannot rely on private/local planning state.
 
 Consequence:
 

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -85,10 +85,11 @@ Pass condition:
 
 Question: Can Orchestra OS run planner/skeptic/shadow/evidence gates without collapsing role boundaries?
 
-Current local evidence:
+Current public evidence:
 
-- `.planning/PROJECT.md` records Phase 2 skeptic and Phase 3-5 infrastructure.
 - `src/services/orchestra/` has tests for config, orchestrator, skeptic, shadow executor, cross-review, evidence arbiter, human gate, promote, promotion store, experiment metrics, and worktree manager.
+- Product-quality reports record current no-provider evidence boundaries without
+  treating removed private planning artifacts as public authority.
 
 Suggested command set:
 
@@ -164,7 +165,7 @@ Current implementation:
 
 - `src/services/orchestra/experimentMetrics.ts`
 - `scripts/orchestra-experiment-runner.ts`
-- `.planning/phase-5/summary-2026-05-07T12-40-41-319Z.md`
+- Product-quality reports and replay fixtures carry current public evidence.
 
 Suggested command:
 
@@ -175,7 +176,8 @@ bun run scripts/orchestra-experiment-runner.ts
 Pass condition:
 
 - Real task set has 20 outcomes, not only mock data.
-- Recommendation follows UVD/FPR/SDC thresholds in code and `.planning/phase-5/SPEC.md`.
+- Recommendation follows UVD/FPR/SDC thresholds in code and current public
+  product-quality evidence, not removed private planning artifacts.
 
 ### EVAL-008 MFH Source Reconciliation Import
 

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -28,9 +28,11 @@ Observed local anchors:
 - `README.md` defines Metaforge as Meta + MFH + Orchestra OS with OpenClaude as
   the local CLI/runtime substrate.
 - `AGENTS.md` already defines the GStack -> GSD -> Superpowers workflow hierarchy and the primary-source research rule.
-- `.planning/PROJECT.md` defines the existing Orchestra vision: a visible
-  lead/evidence arbiter, private planner/skeptic/shadow opposition, tests as
-  law, and the human as final judge, without making public model-lock claims.
+- Legacy planning artifacts and `src/services/orchestra/` define the existing
+  Orchestra vision: a visible lead/evidence arbiter, private
+  planner/skeptic/shadow opposition, tests as law, and the human as final
+  judge, without making public model-lock claims. The legacy planning artifacts
+  are no longer tracked public authority after the public hygiene cleanup.
 - `src/services/orchestra/` already contains implementation surfaces for planner routing, skeptic, shadow executor contract, cross-review, evidence arbiter, human gate, promotion store, worktree manager, and experiment metrics.
 - `package.json` exposes verification commands: `bun run build`, `bun test`, `bun run typecheck`, `bun run smoke`, `bun run doctor:runtime`, `bun run verify:privacy`.
 - `docs/superpowers/specs/2026-05-05-agent-stack-integration-design.md` and its plan document establish the existing GStack/GSD/Superpowers role split.
@@ -125,7 +127,7 @@ Governed-code version: preserve Claude Code/OpenClaude freedom, but turn intent,
 | --- | --- | --- | --- | --- |
 | North Star Goal | Durable strategic direction | Human owner | months | `docs/PROJECT_SPEC.md` |
 | Program Goals | Major capability tracks | Orchestrator + human gate | weeks | `docs/ROADMAP.md` |
-| Sprint Goals | Narrow verifiable increments | Orchestrator | days | `docs/PROGRESS_LOG.md`, `.planning/` phase plans |
+| Sprint Goals | Narrow verifiable increments | Orchestrator | days | `docs/PROGRESS_LOG.md`, `docs/NEXT_GOALS.md`, product-quality reports |
 | Codex Goals | Executable `/goal` prompts | Codex lead | one session | `docs/NEXT_GOALS.md` |
 | Atomic Tasks | Small testable actions | assigned agent role | minutes-hours | diffs, tests, evidence entries |
 

--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -89,6 +89,32 @@ describe('public artifact hygiene scanner', () => {
     expect(`${result.stdout}\n${result.stderr}`).toContain('actual-looking-sk-token')
   })
 
+  test('rejects ignored local tool config files with private paths or runtime context', () => {
+    const repo = makeTempRepo()
+    writeFileSync(
+      join(repo, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          local: {
+            command: windowsPrivatePath,
+          },
+        },
+      }),
+    )
+    const cursorDir = join(repo, '.cursor')
+    mkdirSync(cursorDir, { recursive: true })
+    writeFileSync(
+      join(cursorDir, 'rules.md'),
+      '<codex_internal_context source="goal">\n',
+    )
+
+    const result = runHygiene(repo)
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}\n${result.stderr}`).toContain('.mcp.json')
+    expect(`${result.stdout}\n${result.stderr}`).toContain('.cursor/rules.md')
+  })
+
   test('rejects private workspace placeholders in public docs', () => {
     const repo = makeTempRepo()
     writeFileSync(

--- a/scripts/public-artifact-hygiene.ts
+++ b/scripts/public-artifact-hygiene.ts
@@ -59,10 +59,28 @@ type PublicLeakPattern = {
   appliesTo?: (relativePath: string) => boolean
 }
 
-const ignoredSensitiveRootFiles = readdirSync(root, { withFileTypes: true })
+const ignoredSensitiveRootFileNames = new Set([
+  '.mcp.json',
+  '.npmrc',
+  '.yarnrc.yml',
+  '.bunfig.toml',
+  '.windsurfrules',
+  '.clinerules',
+])
+
+const ignoredSensitiveRootDirectoryNames = new Set([
+  '.claude',
+  '.cursor',
+  '.windsurf',
+])
+
+const ignoredSensitiveRootTargets = readdirSync(root, { withFileTypes: true })
   .filter((entry) => (
-    entry.isFile() &&
-    entry.name.startsWith('.openclaude-profile.json')
+    (entry.isFile() && (
+      entry.name.startsWith('.openclaude-profile.json') ||
+      ignoredSensitiveRootFileNames.has(entry.name)
+    )) ||
+    (entry.isDirectory() && ignoredSensitiveRootDirectoryNames.has(entry.name))
   ))
   .map((entry) => entry.name)
 
@@ -208,7 +226,7 @@ function sanitize(text: string): string {
   )
 }
 
-const files = [...targetRoots, ...ignoredSensitiveRootFiles]
+const files = [...targetRoots, ...ignoredSensitiveRootTargets]
   .map((target) => resolve(root, target))
   .filter((target) => existsSync(target))
   .flatMap(walk)

--- a/scripts/public-repo-readiness.test.ts
+++ b/scripts/public-repo-readiness.test.ts
@@ -317,6 +317,21 @@ describe('public repository readiness surfaces', () => {
     }
   })
 
+  test('public operating docs do not cite removed planning artifacts as current authority', () => {
+    const trackedPlanningArtifacts = trackedRepoPaths(root).filter((path) => path.startsWith('.planning/'))
+    const docs = [
+      'docs/DECISION_LOG.md',
+      'docs/PROJECT_SPEC.md',
+      'docs/EVALS.md',
+    ]
+
+    expect(trackedPlanningArtifacts).toEqual([])
+    for (const path of docs) {
+      const text = readRepoText(path)
+      expect(text, path).not.toMatch(/\.planning\/(?:PROJECT|ROADMAP|phase-)/)
+    }
+  })
+
   test('profile refresh evidence does not expose private workbench repo breadcrumbs', () => {
     const evidence = readRepoText('docs/profile/github-profile-refresh-evidence-2026-06-14.md')
     const forbiddenEvidence = [


### PR DESCRIPTION
## Summary

Follow-up to #92. This turns the remaining public feedback into two tighter trust gates:

- scan ignored local tool config surfaces such as `.mcp.json`, `.npmrc`, `.cursor/`, `.claude/`, and `.windsurf/` for private paths, token-shaped content, and pasted runtime context
- update public operating docs so removed `.planning` artifacts are no longer cited as current authority
- add a public-readiness regression test proving tracked `.planning/` is empty and core docs do not cite removed planning artifacts as current evidence

## Why

The public feedback was not only about one leaked path. It was about trust: public docs should not look like local prompt dumps, and public gates should keep catching new local configuration surfaces before they reach GitHub. This PR makes that expectation executable.

## Validation

- `bun test scripts/public-artifact-hygiene.test.ts scripts/public-repo-readiness.test.ts` PASS, 42 tests
- `bun run verify:privacy` PASS
- `bun run product:quality` PASS locally; terminal condition remains `PRODUCT_QUALITY_GATE_BLOCKED_BY_LOCAL_VSCODE_CLI_UNAVAILABLE`
- `git diff --check` and `git diff --cached --check` PASS

## Research Inputs

Applied current primary-source direction from GitHub secret scanning / push protection, OpenSSF Scorecard, CodeQL, Knip, dependency-cruiser, jscpd, cognitive apprenticeship, worked examples, and dependency/static-analysis patent patterns as trust-gate inspiration. No external validation or security-readiness claim is made here.

## Claim Boundary

This is public hygiene and evidence-gate hardening only. It does not claim production readiness, release readiness, external validation, hosted deployment, benchmark completion, or public security posture.