### PR TITLE
Add Goal Kernel MVP validation

### DIFF
--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -237,3 +237,29 @@ Evidence:
 - `docs/RESEARCH_PIPELINE.md` already requires local-first, primary-source research.
 - `docs/avf/OSS_ASSIMILATION_PIPELINE.md` defines governed acquisition instead of copy-paste adoption.
 - `docs/research/mimesis-engineering-source-ledger-2026-06-14.md` records current product, OSS, paper, patent, and standards sources.
+
+## D-013 - Validate current Codex Goals before migrating historical goal artifacts
+
+Date: 2026-06-18
+Status: accepted
+
+Decision:
+
+The Goal Kernel MVP validates current structured Codex Goal files named
+`CG-*.md` before attempting to migrate older AVF or Influence Factory local
+goal artifacts.
+
+Evidence:
+
+- `docs/GOAL_SCHEMA.md` defines the required Goal OS object.
+- `docs/NEXT_GOALS.md` asks for one real goal file and a narrow validator.
+- `docs/goals/` already contains many historical local artifacts that are
+  useful evidence but were not authored against the new schema.
+
+Consequence:
+
+- `scripts/validate-goals.ts` treats `docs/goals/CG-*.md` as the current
+  machine-checkable registry.
+- Historical goal artifacts remain public-surface-scanned evidence, but they
+  are not rewritten or treated as schema-valid Goal Kernel records in this
+  slice.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -73,3 +73,32 @@ Status: active
   - target docs contain no open-work placeholder markers
   - required Goal OS plus MFH/Meta terms are present
 - Re-ran OpenClaude build sanity check: `bun run build` passed.
+
+## 2026-06-18 Checkpoint 8 - Goal Kernel MVP Start
+
+- Read `AGENTS.md`, `docs/NEXT_GOALS.md`, `docs/GOAL_SCHEMA.md`,
+  `docs/MFH_META_SYNTHESIS.md`, `docs/ROADMAP.md`, `docs/PROGRESS_LOG.md`,
+  and `docs/DECISION_LOG.md`.
+- Created the current structured goal registry entry:
+  `docs/goals/CG-001-goal-kernel-mvp.md`.
+- Created `docs/goals/README.md` to distinguish current `CG-*.md` goal
+  objects from historical local goal artifacts.
+- Added `scripts/validate-goals.ts` and `scripts/validate-goals.test.ts` for
+  required Goal OS fields, validation commands, pause conditions, rollback,
+  governed-code claim boundaries, MFH gates, and Meta records.
+- Added `goals:validate` to `package.json`.
+- Recorded D-013 so historical local goal artifacts are not rewritten as part
+  of the first Goal Kernel validator slice.
+- Validation results:
+  - `bun test scripts/validate-goals.test.ts` passed with 3 tests.
+  - `bun run goals:validate` passed with 1 valid `CG-*.md` goal and no
+    provider, live model, external, or protected calls.
+  - `bun run build` passed.
+  - `bun run product:typecheck-health` passed with 0 diagnostics.
+  - `bun run product:public-claim-boundary:check` passed with 0 unauthorized
+    positive claims.
+  - `bun run verify:privacy` passed.
+- Direct `bun run typecheck --pretty false` exposed broad existing `src/`
+  TypeScript diagnostics outside this docs-governance change; the changed
+  goal validator path passed focused tests and the repo's product typecheck
+  health gate.

--- a/docs/goals/CG-001-goal-kernel-mvp.md
+++ b/docs/goals/CG-001-goal-kernel-mvp.md
@@ -1,0 +1,239 @@
+# CG-001 Goal Kernel MVP
+
+Boundary: this is a local no-provider docs-governance goal object. It proves
+that one Goal OS record is machine-checkable against MFH/Meta fields after the
+validator passes. It does not prove production readiness, release readiness,
+public readiness, external validation, or autonomous reliability.
+
+```yaml
+id: CG-001
+level: CodexGoal
+title: Implement Goal Kernel MVP
+parent: SG-001
+status: active
+owner: Orchestrator
+createdAt: 2026-06-18
+updatedAt: 2026-06-18
+
+objective:
+  summary: Create a machine-checkable goal registry for the Autonomous Goal OS.
+  whyNow: Metaforge needs proof-bound goal state before stronger Meta/MFH/Orchestra marketing claims.
+  userValue: The owner gets durable execution state, non-goals, validation commands, and claim boundaries without becoming the technical bottleneck.
+
+scope:
+  in:
+    - Create the current structured goal registry entry.
+    - Add a local validator for required Goal OS fields.
+    - Bind the goal to MFH gate flags and Meta record fields.
+    - Record local validation commands and claim boundaries.
+  out:
+    - Public deployment.
+    - Credential or provider changes.
+    - Live model calls.
+    - External benchmark submission.
+    - Automation creation.
+    - Rewriting historical AVF or Influence Factory goal artifacts.
+  targetFiles:
+    - docs/goals/README.md
+    - docs/goals/CG-001-goal-kernel-mvp.md
+    - scripts/validate-goals.ts
+    - scripts/validate-goals.test.ts
+    - package.json
+    - docs/PROGRESS_LOG.md
+    - docs/DECISION_LOG.md
+  targetDomain: docs-governance
+
+context:
+  localSourcesRead:
+    - AGENTS.md
+    - docs/NEXT_GOALS.md
+    - docs/GOAL_SCHEMA.md
+    - docs/PROJECT_SPEC.md
+    - docs/MFH_META_SYNTHESIS.md
+    - docs/ROADMAP.md
+    - docs/EVALS.md
+    - package.json
+  externalPrimarySources:
+    - title: W3C PROV-DM
+      url: https://www.w3.org/TR/prov-dm/
+      reason: Models provenance as entities, activities, and agents for evidence-bearing state.
+    - title: NIST AI Risk Management Framework
+      url: https://www.nist.gov/itl/ai-risk-management-framework
+      reason: Frames trustworthy AI work as design, development, use, and evaluation controls.
+    - title: OpenAI Agent Evals
+      url: https://developers.openai.com/api/docs/guides/agent-evals
+      reason: Supports trace, grader, dataset, and eval-run based agent quality loops.
+    - title: OpenAI Trace Grading
+      url: https://developers.openai.com/api/docs/guides/trace-grading
+      reason: Supports trace-level assessment rather than final-output-only claims.
+    - title: ReAct paper
+      url: https://arxiv.org/abs/2210.03629
+      reason: Supports interleaved reasoning and acting trajectories as inspectable agent behavior.
+    - title: USPTO Patent Public Search
+      url: https://www.uspto.gov/patents/search/patent-public-search
+      reason: Keeps patent search as a primary-source lane before stronger product-method claims.
+  relatedDecisions:
+    - D-008
+    - D-009
+    - D-010
+    - D-011
+    - D-012
+
+researchRequirements:
+  required: true
+  sourceLadder:
+    - local repo evidence
+    - official docs
+    - original repositories
+    - papers
+    - patents
+    - standards
+  rejectedSources:
+    - blog-only summaries without original source links
+  openQuestions:
+    - Whether future goals should use separate YAML files after the Markdown registry proves stable.
+
+successCriteria:
+  - id: SC-001
+    statement: The CG-001 goal file validates as a structured Codex Goal.
+    validation: bun run goals:validate
+  - id: SC-002
+    statement: The validator rejects missing success criteria and MFH gate fields.
+    validation: bun test scripts/validate-goals.test.ts
+  - id: SC-003
+    statement: The repo still builds after the docs-governance script is added.
+    validation: bun run build
+  - id: SC-004
+    statement: Claim boundaries remain explicit and no protected actions are performed.
+    validation: bun run goals:validate and bun run verify:privacy
+
+validationCommands:
+  - command: bun run goals:validate
+    expected: exit 0
+    required: true
+  - command: bun test scripts/validate-goals.test.ts
+    expected: all tests pass
+    required: true
+  - command: bun run build
+    expected: exit 0
+    required: true
+  - command: bun run verify:privacy
+    expected: exit 0
+    required: false
+
+checkpoints:
+  - id: CP-001
+    name: Read existing Goal OS state
+    doneWhen: Local and primary-source inputs are listed in this goal object.
+  - id: CP-002
+    name: Add validator
+    doneWhen: The goal validator exists and rejects missing required fields.
+  - id: CP-003
+    name: Add first structured goal
+    doneWhen: The CG-001 goal file validates.
+  - id: CP-004
+    name: Record outcome
+    doneWhen: Progress and decision logs mention the Goal Kernel MVP.
+
+pauseConditions:
+  - A protected action, credential change, provider activation, public deployment, or automation creation is needed.
+  - External benchmark or external validation is required to support a claim.
+  - The validator would need to rewrite historical local goal artifacts.
+  - A source cannot be verified from local repo evidence or primary material.
+
+rollbackStrategy:
+  type: file-revert
+  steps:
+    - Revert `docs/goals/README.md`.
+    - Revert `docs/goals/CG-001-goal-kernel-mvp.md`.
+    - Revert `scripts/validate-goals.ts` and `scripts/validate-goals.test.ts`.
+    - Remove `goals:validate` from `package.json`.
+    - Revert progress and decision log additions.
+  validationAfterRollback:
+    - bun run build
+
+agentAssignments:
+  orchestrator: Owns goal state, branch scope, and stop/go decisions.
+  researcher: Provides primary-source anchors and rejected-source boundaries.
+  architect: Converts Goal OS schema into a narrow validator contract.
+  implementer: Edits the scoped docs-governance files.
+  eval: Runs validation commands and records pass or failure.
+  security: Reviews protected-action, credential, external-call, and claim boundaries.
+  memoryLibrarian: Proposes durable memory or skill promotion only after repeated success.
+
+evidence:
+  artifacts:
+    - docs/goals/README.md
+    - docs/goals/CG-001-goal-kernel-mvp.md
+    - scripts/validate-goals.ts
+    - scripts/validate-goals.test.ts
+    - docs/product-quality/goal-validation-report.json
+  testResults:
+    - command: bun run goals:validate
+      status: pass
+      outputSummary: 1 goal file passed, 0 invalid, with no provider, live model, external, or protected calls.
+    - command: bun test scripts/validate-goals.test.ts
+      status: pass
+      outputSummary: 3 tests passed, including MFH/Meta fields, missing gate fields, malformed item fields, filename mismatch, and missing local sources.
+    - command: bun run build
+      status: pass
+      outputSummary: Built openclaude v0.6.0 to dist/cli.mjs.
+    - command: bun run verify:privacy
+      status: pass
+      outputSummary: No banned build-output patterns, no unauthorized positive public claims, and no origin/license provenance blockers.
+  traceLinks: []
+
+reflection:
+  result: keep
+  lessons:
+    - The first registry slice should validate only `CG-*.md` files so historical local artifacts can remain as evidence without being rewritten.
+  nextGoalCandidates:
+    - CG-002-primary-source-research-ledger
+    - CG-003-eval-flywheel-source-reconciliation
+
+governedCode:
+  category: governed-code
+  claimLevel: internal_substrate
+  claimBoundary:
+    allowed:
+      - A local structured Codex Goal can be validated for required Goal OS, MFH, and Meta fields.
+      - Historical goal artifacts remain local evidence and are not upgraded by this slice.
+    forbidden:
+      - Production readiness.
+      - Release readiness.
+      - Public readiness.
+      - External validation.
+      - Autonomous reliability.
+      - Hosted deployment or benchmark success.
+  authoritySources:
+    - docs/PROJECT_SPEC.md
+    - docs/GOAL_SCHEMA.md
+    - docs/MFH_META_SYNTHESIS.md
+    - docs/ROADMAP.md
+    - docs/EVALS.md
+    - docs/SECURITY_AND_GUARDRAILS.md
+  mfhGates:
+    sourceReconcilerRequired: true
+    closureRealityRequired: true
+    dirtyStateAttributionRequired: true
+    humanAdjudicationRequired: true
+  metaRecords:
+    decisionLedgerEntries:
+      - docs/DECISION_LOG.md#D-009
+      - docs/DECISION_LOG.md#D-010
+      - docs/DECISION_LOG.md#D-013
+    rawSources:
+      - docs/NEXT_GOALS.md
+      - docs/GOAL_SCHEMA.md
+      - docs/MFH_META_SYNTHESIS.md
+      - docs/ROADMAP.md
+    wikiOrMemoryUpdates: []
+```
+
+## Current Human-Readable Summary
+
+This goal turns the planning-package idea of a Goal Kernel into one concrete
+registry entry plus a validator. It deliberately does not rewrite every older
+goal artifact because that would mix public hygiene work with a broad migration.
+Future goals can migrate or retire historical records in smaller, verified
+slices.

--- a/docs/goals/README.md
+++ b/docs/goals/README.md
@@ -1,0 +1,26 @@
+# Goal Registry
+
+Status: active local docs-governance surface
+
+This directory contains both historical local goal artifacts and the current
+Autonomous Goal OS goal registry.
+
+The machine-checkable registry is intentionally narrow:
+
+- Current structured goal objects use `CG-*.md` file names.
+- Each structured goal contains a fenced `yaml` object following
+  `docs/GOAL_SCHEMA.md`.
+- Historical AVF and Influence Factory artifacts remain local evidence inputs;
+  they are not rewritten into the new schema in this slice.
+
+Validation:
+
+```bash
+bun run goals:validate
+```
+
+The validator checks required objective, scope, non-goal, success-criteria,
+validation-command, checkpoint, pause-condition, rollback, research,
+governed-code, MFH gate, and Meta record fields. A passing goal object is local
+governance evidence only. It does not prove production readiness, release
+readiness, public readiness, external validation, or autonomous reliability.

--- a/docs/product-quality/goal-validation-report.json
+++ b/docs/product-quality/goal-validation-report.json
@@ -1,0 +1,20 @@
+{
+  "generatedAt": "2026-06-18T09:33:35.783Z",
+  "mode": "local_no_provider_goal_validation",
+  "goalFileCount": 1,
+  "validGoalCount": 1,
+  "invalidGoalCount": 0,
+  "providerCallsPerformed": [],
+  "liveModelCallsPerformed": [],
+  "externalCallsPerformed": [],
+  "protectedActionsExecuted": [],
+  "validationResults": [
+    {
+      "path": "docs/goals/CG-001-goal-kernel-mvp.md",
+      "goalId": "CG-001",
+      "ok": true,
+      "errors": []
+    }
+  ],
+  "claimBoundary": "Goal validation is local docs governance evidence only. It does not prove production readiness, release readiness, public readiness, external validation, or autonomous reliability."
+}

--- a/docs/product-quality/typecheck-health-report.json
+++ b/docs/product-quality/typecheck-health-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-18T09:11:20.336Z",
+  "generatedAt": "2026-06-18T09:32:45.719Z",
   "command": "bun run typecheck",
   "strictPass": true,
   "exitCode": 0,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "doctor:runtime": "bun run scripts/system-check.ts",
     "doctor:runtime:json": "bun run scripts/system-check.ts --json",
     "doctor:report": "bun run scripts/system-check.ts --out reports/doctor-runtime.json",
+    "goals:validate": "bun run scripts/validate-goals.ts",
     "hardening:check": "bun run smoke && bun run doctor:runtime",
     "hardening:strict": "bun run typecheck && bun run hardening:check",
     "product:typecheck-health": "bun run scripts/typecheck-health.ts",

--- a/scripts/validate-goals.test.ts
+++ b/scripts/validate-goals.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+
+import { validateGoalDocument } from './validate-goals'
+
+const validGoal = `# CG-001 Goal Kernel MVP
+
+\`\`\`yaml
+id: CG-001
+level: CodexGoal
+title: Implement Goal Kernel MVP
+parent: SG-001
+status: active
+owner: Orchestrator
+createdAt: 2026-06-18
+updatedAt: 2026-06-18
+objective:
+  summary: Create a machine-checkable goal registry.
+  whyNow: Public claims need evidence-backed goal state.
+  userValue: Reduces owner execution bottleneck.
+scope:
+  in:
+    - docs/goals/CG-001-goal-kernel-mvp.md
+  out:
+    - public deployment
+  targetFiles:
+    - docs/goals/CG-001-goal-kernel-mvp.md
+  targetDomain: docs-governance
+context:
+  localSourcesRead:
+    - AGENTS.md
+  externalPrimarySources:
+    - title: W3C PROV-DM
+      url: https://www.w3.org/TR/prov-dm/
+      reason: Models provenance with entities, activities, and agents.
+  relatedDecisions:
+    - D-009
+researchRequirements:
+  required: true
+  sourceLadder:
+    - official docs
+    - papers
+  rejectedSources:
+    - blog-only summary without primary source
+  openQuestions:
+    - none
+successCriteria:
+  - id: SC-001
+    statement: Goal validator passes.
+    validation: bun run goals:validate
+validationCommands:
+  - command: bun run goals:validate
+    expected: exit 0
+    required: true
+checkpoints:
+  - id: CP-001
+    name: Write validator
+    doneWhen: Validator accepts CG-001.
+pauseConditions:
+  - Protected action required.
+rollbackStrategy:
+  type: file-revert
+  steps:
+    - Revert docs and validator files.
+  validationAfterRollback:
+    - bun run goals:validate
+agentAssignments:
+  orchestrator: Owns goal state.
+  researcher: Provides primary-source ledger.
+  architect: Converts evidence into design.
+  implementer: Edits scoped files.
+  eval: Runs validation.
+  security: Reviews permission gates.
+  memoryLibrarian: Proposes promotion.
+evidence:
+  artifacts:
+    - docs/goals/CG-001-goal-kernel-mvp.md
+  testResults:
+    - command: bun run goals:validate
+      status: not_run
+      outputSummary: Pending.
+  traceLinks: []
+reflection:
+  result: unknown
+  lessons:
+    - Pending validation.
+  nextGoalCandidates:
+    - CG-002
+governedCode:
+  category: governed-code
+  claimLevel: internal_substrate
+  claimBoundary:
+    allowed:
+      - A local goal object validates against required MFH/Meta fields.
+    forbidden:
+      - Production readiness.
+  authoritySources:
+    - docs/PROJECT_SPEC.md
+    - docs/MFH_META_SYNTHESIS.md
+  mfhGates:
+    sourceReconcilerRequired: true
+    closureRealityRequired: true
+    dirtyStateAttributionRequired: true
+    humanAdjudicationRequired: true
+  metaRecords:
+    decisionLedgerEntries:
+      - docs/DECISION_LOG.md#D-009
+    rawSources:
+      - docs/GOAL_SCHEMA.md
+    wikiOrMemoryUpdates: []
+\`\`\`
+`
+
+describe('goal validator', () => {
+  test('accepts a Goal Kernel object with MFH and Meta gate fields', () => {
+    const result = validateGoalDocument('docs/goals/CG-001-goal-kernel-mvp.md', validGoal)
+
+    expect(result.ok).toBe(true)
+    expect(result.goalId).toBe('CG-001')
+    expect(result.errors).toEqual([])
+  })
+
+  test('rejects missing required success criteria and governed-code gate fields', () => {
+    const invalid = validGoal
+      .replace('successCriteria:', 'successCriteriaMissing:')
+      .replace('  mfhGates:', '  mfhGatesMissing:')
+
+    const result = validateGoalDocument('docs/goals/CG-001-goal-kernel-mvp.md', invalid)
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('successCriteria must contain at least one item')
+    expect(result.errors).toContain('governedCode.mfhGates.sourceReconcilerRequired must be boolean')
+  })
+
+  test('rejects malformed item fields, filename mismatch, and missing local sources', () => {
+    const invalid = validGoal
+      .replace('    - title: W3C PROV-DM', '    - title: W3C PROV-DM')
+      .replace('    - AGENTS.md', '    - docs/MISSING_LOCAL_SOURCE.md')
+      .replace('  - id: SC-001\n    statement: Goal validator passes.', '  - statement: Goal validator passes.')
+      .replace('  - id: CP-001\n    name: Write validator', '  - id: CP-001')
+      .replace('    wikiOrMemoryUpdates: []', '    wikiOrMemoryUpdates: missing')
+
+    const result = validateGoalDocument('docs/goals/CG-999-wrong-file.md', invalid)
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('id must match filename prefix CG-999')
+    expect(result.errors).toContain('context.localSourcesRead.0 must point to an existing local source')
+    expect(result.errors).toContain('successCriteria.0.id must be a non-empty string')
+    expect(result.errors).toContain('checkpoints.0.name must be a non-empty string')
+    expect(result.errors).toContain('governedCode.metaRecords.wikiOrMemoryUpdates must be an array')
+  })
+})

--- a/scripts/validate-goals.ts
+++ b/scripts/validate-goals.ts
@@ -1,0 +1,315 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'yaml'
+
+type ValidationResult = {
+  path: string
+  goalId: string | null
+  ok: boolean
+  errors: string[]
+}
+
+type ValidationReport = {
+  generatedAt: string
+  mode: 'local_no_provider_goal_validation'
+  goalFileCount: number
+  validGoalCount: number
+  invalidGoalCount: number
+  providerCallsPerformed: []
+  liveModelCallsPerformed: []
+  externalCallsPerformed: []
+  protectedActionsExecuted: []
+  validationResults: ValidationResult[]
+  claimBoundary: string
+}
+
+const root = process.cwd()
+const goalDir = 'docs/goals'
+const reportDir = 'docs/product-quality'
+const reportPath = 'docs/product-quality/goal-validation-report.json'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function hasNonEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0
+}
+
+function getPath(value: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((current, part) => {
+    if (!isRecord(current)) return undefined
+    return current[part]
+  }, value)
+}
+
+function extractYamlBlock(markdown: string): string | null {
+  const match = markdown.match(/```ya?ml\s*\r?\n([\s\S]*?)\r?\n```/i)
+  return match?.[1] ?? null
+}
+
+function requireString(goal: unknown, path: string, errors: string[]): void {
+  if (!hasNonEmptyString(getPath(goal, path))) {
+    errors.push(`${path} must be a non-empty string`)
+  }
+}
+
+function requireArray(goal: unknown, path: string, errors: string[]): void {
+  if (!hasNonEmptyArray(getPath(goal, path))) {
+    errors.push(`${path} must contain at least one item`)
+  }
+}
+
+function requireArrayValue(goal: unknown, path: string, errors: string[]): void {
+  if (!Array.isArray(getPath(goal, path))) {
+    errors.push(`${path} must be an array`)
+  }
+}
+
+function requireBoolean(goal: unknown, path: string, errors: string[]): void {
+  if (typeof getPath(goal, path) !== 'boolean') {
+    errors.push(`${path} must be boolean`)
+  }
+}
+
+function localPathExists(path: string): boolean {
+  return existsSync(resolve(root, path.split('#')[0] ?? path))
+}
+
+function requireLocalPathArray(goal: unknown, path: string, errors: string[]): void {
+  const value = getPath(goal, path)
+  if (!Array.isArray(value)) return
+  value.forEach((entry, index) => {
+    if (!hasNonEmptyString(entry) || !localPathExists(String(entry))) {
+      errors.push(`${path}.${index} must point to an existing local source`)
+    }
+  })
+}
+
+export function validateGoalDocument(path: string, markdown: string): ValidationResult {
+  const yamlBlock = extractYamlBlock(markdown)
+  if (!yamlBlock) {
+    return {
+      path,
+      goalId: null,
+      ok: false,
+      errors: ['goal document must contain a yaml fenced block'],
+    }
+  }
+
+  let goal: unknown
+  try {
+    goal = parse(yamlBlock)
+  } catch (error) {
+    return {
+      path,
+      goalId: null,
+      ok: false,
+      errors: [`goal yaml must parse: ${error instanceof Error ? error.message : String(error)}`],
+    }
+  }
+
+  const errors: string[] = []
+  const goalId = hasNonEmptyString(getPath(goal, 'id')) ? String(getPath(goal, 'id')) : null
+  const fileName = path.split('/').pop() ?? path
+  const fileIdMatch = fileName.match(/^(CG-\d+)-/i)
+  const fileGoalId = fileIdMatch?.[1]?.toUpperCase()
+  if (fileGoalId && goalId && goalId.toUpperCase() !== fileGoalId) {
+    errors.push(`id must match filename prefix ${fileGoalId}`)
+  }
+
+  for (const field of [
+    'id',
+    'level',
+    'title',
+    'parent',
+    'status',
+    'owner',
+    'createdAt',
+    'updatedAt',
+    'objective.summary',
+    'objective.whyNow',
+    'objective.userValue',
+    'scope.targetDomain',
+    'rollbackStrategy.type',
+    'reflection.result',
+    'governedCode.category',
+    'governedCode.claimLevel',
+  ]) {
+    requireString(goal, field, errors)
+  }
+
+  for (const field of [
+    'scope.in',
+    'scope.out',
+    'scope.targetFiles',
+    'context.localSourcesRead',
+    'context.externalPrimarySources',
+    'context.relatedDecisions',
+    'researchRequirements.sourceLadder',
+    'researchRequirements.rejectedSources',
+    'researchRequirements.openQuestions',
+    'successCriteria',
+    'validationCommands',
+    'checkpoints',
+    'pauseConditions',
+    'rollbackStrategy.steps',
+    'rollbackStrategy.validationAfterRollback',
+    'evidence.artifacts',
+    'evidence.testResults',
+    'reflection.lessons',
+    'reflection.nextGoalCandidates',
+    'governedCode.claimBoundary.allowed',
+    'governedCode.claimBoundary.forbidden',
+    'governedCode.authoritySources',
+    'governedCode.metaRecords.decisionLedgerEntries',
+    'governedCode.metaRecords.rawSources',
+  ]) {
+    requireArray(goal, field, errors)
+  }
+  requireArrayValue(goal, 'governedCode.metaRecords.wikiOrMemoryUpdates', errors)
+
+  for (const field of [
+    'researchRequirements.required',
+    'governedCode.mfhGates.sourceReconcilerRequired',
+    'governedCode.mfhGates.closureRealityRequired',
+    'governedCode.mfhGates.dirtyStateAttributionRequired',
+    'governedCode.mfhGates.humanAdjudicationRequired',
+  ]) {
+    requireBoolean(goal, field, errors)
+  }
+
+  const agentAssignments = getPath(goal, 'agentAssignments')
+  for (const role of ['orchestrator', 'researcher', 'architect', 'implementer', 'eval', 'security', 'memoryLibrarian']) {
+    if (!isRecord(agentAssignments) || !hasNonEmptyString(agentAssignments[role])) {
+      errors.push(`agentAssignments.${role} must be a non-empty string`)
+    }
+  }
+
+  const commands = getPath(goal, 'validationCommands')
+  if (Array.isArray(commands)) {
+    commands.forEach((command, index) => {
+      if (!isRecord(command) || !hasNonEmptyString(command.command)) {
+        errors.push(`validationCommands.${index}.command must be a non-empty string`)
+      }
+      if (!isRecord(command) || !hasNonEmptyString(command.expected)) {
+        errors.push(`validationCommands.${index}.expected must be a non-empty string`)
+      }
+      if (!isRecord(command) || typeof command.required !== 'boolean') {
+        errors.push(`validationCommands.${index}.required must be boolean`)
+      }
+    })
+  }
+
+  const successCriteria = getPath(goal, 'successCriteria')
+  if (Array.isArray(successCriteria)) {
+    successCriteria.forEach((criterion, index) => {
+      for (const field of ['id', 'statement', 'validation']) {
+        if (!isRecord(criterion) || !hasNonEmptyString(criterion[field])) {
+          errors.push(`successCriteria.${index}.${field} must be a non-empty string`)
+        }
+      }
+    })
+  }
+
+  const checkpoints = getPath(goal, 'checkpoints')
+  if (Array.isArray(checkpoints)) {
+    checkpoints.forEach((checkpoint, index) => {
+      for (const field of ['id', 'name', 'doneWhen']) {
+        if (!isRecord(checkpoint) || !hasNonEmptyString(checkpoint[field])) {
+          errors.push(`checkpoints.${index}.${field} must be a non-empty string`)
+        }
+      }
+    })
+  }
+
+  const externalSources = getPath(goal, 'context.externalPrimarySources')
+  if (Array.isArray(externalSources)) {
+    externalSources.forEach((source, index) => {
+      for (const field of ['title', 'url', 'reason']) {
+        if (!isRecord(source) || !hasNonEmptyString(source[field])) {
+          errors.push(`context.externalPrimarySources.${index}.${field} must be a non-empty string`)
+        }
+      }
+      if (isRecord(source) && hasNonEmptyString(source.url) && !/^https?:\/\//.test(String(source.url))) {
+        errors.push(`context.externalPrimarySources.${index}.url must be an http(s) URL`)
+      }
+    })
+  }
+
+  requireLocalPathArray(goal, 'context.localSourcesRead', errors)
+  requireLocalPathArray(goal, 'governedCode.authoritySources', errors)
+  requireLocalPathArray(goal, 'governedCode.metaRecords.rawSources', errors)
+  requireLocalPathArray(goal, 'governedCode.metaRecords.decisionLedgerEntries', errors)
+
+  return {
+    path,
+    goalId,
+    ok: errors.length === 0,
+    errors,
+  }
+}
+
+function listGoalFiles(): string[] {
+  const absoluteGoalDir = resolve(root, goalDir)
+  if (!existsSync(absoluteGoalDir)) return []
+  return readdirSync(absoluteGoalDir)
+    .filter((name) => /^CG-\d+-.*\.md$/i.test(name))
+    .sort((left, right) => left.localeCompare(right))
+    .map((name) => `${goalDir}/${name}`)
+}
+
+function buildReport(goalFiles = listGoalFiles()): ValidationReport {
+  const validationResults = goalFiles.map((path) =>
+    validateGoalDocument(path, readFileSync(resolve(root, path), 'utf8')),
+  )
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'local_no_provider_goal_validation',
+    goalFileCount: goalFiles.length,
+    validGoalCount: validationResults.filter((result) => result.ok).length,
+    invalidGoalCount: validationResults.filter((result) => !result.ok).length,
+    providerCallsPerformed: [],
+    liveModelCallsPerformed: [],
+    externalCallsPerformed: [],
+    protectedActionsExecuted: [],
+    validationResults,
+    claimBoundary: 'Goal validation is local docs governance evidence only. It does not prove production readiness, release readiness, public readiness, external validation, or autonomous reliability.',
+  }
+}
+
+function main(): void {
+  const report = buildReport()
+  mkdirSync(resolve(root, reportDir), { recursive: true })
+  writeFileSync(resolve(root, reportPath), `${JSON.stringify(report, null, 2)}\n`)
+
+  for (const result of report.validationResults) {
+    const prefix = result.ok ? 'PASS' : 'FAIL'
+    console.log(`${prefix}: ${result.path}${result.goalId ? ` (${result.goalId})` : ''}`)
+    for (const error of result.errors) {
+      console.log(`  - ${error}`)
+    }
+  }
+
+  console.log('')
+  console.log(`RESULT: ${report.invalidGoalCount === 0 && report.goalFileCount > 0 ? 'PASS' : 'FAIL'}`)
+  console.log(`goal_file_count=${report.goalFileCount}`)
+  console.log(`valid_goal_count=${report.validGoalCount}`)
+  console.log(`invalid_goal_count=${report.invalidGoalCount}`)
+  console.log('provider_calls_performed=0')
+  console.log('live_model_calls_performed=0')
+  console.log('external_calls_performed=0')
+  console.log('protected_actions_executed=0')
+
+  if (report.goalFileCount === 0 || report.invalidGoalCount > 0) {
+    process.exit(1)
+  }
+}
+
+if (import.meta.main) {
+  main()
+}


### PR DESCRIPTION
## Summary
- add the first current structured Goal Kernel record at docs/goals/CG-001-goal-kernel-mvp.md
- add docs/goals/README.md to separate current CG-* goal records from historical local goal artifacts
- add goals:validate and a local no-provider validator for required Goal OS, MFH gate, and Meta record fields
- record the legacy-artifact boundary decision and validation progress

## Verification
- bun test scripts/validate-goals.test.ts
- bun run goals:validate
- bun run build
- bun run product:typecheck-health
- bun run product:public-claim-boundary:check
- bun run verify:privacy

## Boundary
- No provider calls, live model calls, external calls, protected actions, credentials, deployment, or automation creation.
- Direct bun run typecheck --pretty false currently reports broad src diagnostics outside this docs-governance change; the repo product:typecheck-health gate passed with 0 diagnostics.
- This is local docs-governance proof only, not production/readiness/external-validation/autonomous-reliability proof.