### PR TITLE
Remove private folder sentinel from public hygiene

### DIFF
--- a/docs/product-quality/agent-instructions-quality-report.json
+++ b/docs/product-quality/agent-instructions-quality-report.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-06-18T09:12:16.168Z",
+  "generatedAt": "2026-06-18T14:41:24.220Z",
   "mode": "local_no_provider_agent_instructions_quality",
   "sourceAgentInstructionsPath": "AGENTS.md",
   "sourceAgentInstructionsSha256": "fdcfd6ad8a694d6f0e935335d03725f68828dcd23cade44929b8affc9c115dcb",
   "sourcePackageJsonPath": "package.json",
-  "sourcePackageJsonSha256": "8f31a9122dc43bebd29aa1f2c3249654e4968f65f2e6171deb64dbec75a98ff0",
+  "sourcePackageJsonSha256": "5e7e0a30ea9855b30aa1f5e6a99de4c4b360dfe125b654f1c5d4f27fd285f664",
   "sourceWorkflowPaths": [
     ".github/workflows/pr-checks.yml",
     ".github/workflows/codeql.yml",

--- a/scripts/product-agent-instructions-quality.ts
+++ b/scripts/product-agent-instructions-quality.ts
@@ -60,7 +60,7 @@ function privateLocalPathNeedles(): string[] {
   return [
     ['C:', 'Users'].join('\\'),
     ['C:', 'Users'].join('/'),
-    ['내 순수', ' 재미'].join(''),
+    ['/Users', '/'].join(''),
   ]
 }
 

--- a/scripts/public-repo-readiness.test.ts
+++ b/scripts/public-repo-readiness.test.ts
@@ -21,8 +21,14 @@ function privateLocalPathNeedles(): string[] {
   return [
     `C:${'\\\\'}Users`,
     `C:${'/'}Users`,
-    ['내 순수', ' 재미'].join(''),
+    `/Users${'/'}`,
   ]
+}
+
+function privateLocalPathNeedleFunctionBody(relativePath: string): string {
+  const match = readRepoText(relativePath).match(/function privateLocalPathNeedles\(\): string\[\] \{([\s\S]*?)\n\}/)
+  expect(match).not.toBeNull()
+  return match?.[1] ?? ''
 }
 
 function readTextFrom(basePath: string, relativePath: string): string {
@@ -108,6 +114,16 @@ function listFilesUnder(relativePath: string): string[] {
 }
 
 describe('public repository readiness surfaces', () => {
+  test('private-path sentinels stay generic instead of embedding local folder names', () => {
+    const sentinelBodies = [
+      privateLocalPathNeedleFunctionBody('scripts/product-agent-instructions-quality.ts'),
+      privateLocalPathNeedleFunctionBody('scripts/public-repo-readiness.test.ts'),
+    ].join('\n')
+
+    expect(sentinelBodies).toContain('Users')
+    expect(sentinelBodies).not.toMatch(/\p{Script=Hangul}/u)
+  })
+
   test('AGENTS.md is public-facing guidance, not a private memory dump', () => {
     const agents = readRepoText('AGENTS.md')
     const lineCount = agents.split(/\r?\n/).length


### PR DESCRIPTION
﻿## Summary
- remove the private localized folder-name sentinel from public hygiene fixtures
- keep generic Windows/macOS home-path detection for local path leaks
- add a public-repo readiness regression test so privacy sentinels stay generic
- refresh the agent-instructions quality report after the related gate

## Verification
- bun install --frozen-lockfile
- bun test scripts/public-repo-readiness.test.ts --test-name-pattern "private-path sentinels stay generic"
- bun run product:public-repo-readiness
- bun run product:agent-instructions-quality
- bun run verify:privacy
- bun run build
- bun run product:quality
- git diff --check
- rg -n "private-folder-fragments and admin-local-path patterns" -- .

## Boundaries
- `bun run typecheck --pretty false` still reports pre-existing runtime TypeScript diagnostics outside this public-hygiene patch.
- `bun run product:quality` exited 0, but the local quality report still carries the protected local VS Code CLI availability boundary; this PR does not claim release, production, or external validation readiness.
