### PR TITLE
[codex] Align issue templates with Metaforge framing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a reproducible problem in OpenClaude
+about: Report a reproducible problem in Metaforge or its OpenClaude runtime substrate
 title: "[Bug]: "
 labels: "bug, triage"
 assignees: ""
@@ -26,7 +26,7 @@ What happened instead?
 
 ## Environment
 
-- OpenClaude version:
+- Metaforge commit or OpenClaude runtime version:
 - OS:
 - Terminal:
 - Provider:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an improvement or new capability for OpenClaude
+about: Suggest an improvement for Metaforge, Meta/MFH/Orchestra OS, or its OpenClaude runtime substrate
 title: "[Feature]: "
 labels: "enhancement, triage"
 assignees: ""
@@ -8,7 +8,7 @@ assignees: ""
 
 ## Summary
 
-What would you like OpenClaude to do?
+What would you like Metaforge to do?
 
 ## Problem
 

--- a/scripts/public-repo-readiness.test.ts
+++ b/scripts/public-repo-readiness.test.ts
@@ -258,6 +258,18 @@ describe('public repository readiness surfaces', () => {
     expect(releaseWorkflow).not.toContain('Gitlawb/openclaude')
   })
 
+  test('issue templates keep Metaforge as the public thesis', () => {
+    const bugReport = readRepoText('.github/ISSUE_TEMPLATE/bug_report.md')
+    const featureRequest = readRepoText('.github/ISSUE_TEMPLATE/feature_request.md')
+
+    expect(bugReport).toContain('Metaforge or its OpenClaude runtime substrate')
+    expect(bugReport).toContain('Metaforge commit or OpenClaude runtime version')
+    expect(bugReport).not.toContain('Report a reproducible problem in OpenClaude')
+    expect(featureRequest).toContain('Metaforge, Meta/MFH/Orchestra OS, or its OpenClaude runtime substrate')
+    expect(featureRequest).toContain('What would you like Metaforge to do?')
+    expect(featureRequest).not.toContain('What would you like OpenClaude to do?')
+  })
+
   test('README states runtime wiring honestly', () => {
     const readme = readRepoText('README.md')
     const koreanReadme = readRepoText('README.ko.md')


### PR DESCRIPTION
## Summary
- Reframes bug and feature issue templates around Metaforge / Meta + MFH + Orchestra OS.
- Keeps OpenClaude visible only as the runtime substrate path where relevant.
- Adds a public-readiness regression test so issue templates do not drift back to OpenClaude-first copy.

## Verification
- `bun test scripts/public-repo-readiness.test.ts scripts/product-public-claim-boundary.test.ts`
- `bun run build`
- `bun run verify:privacy`
- `bun run product:quality`
- `git diff --check`

## Boundary
`bun run typecheck --pretty false` still reports pre-existing broad `src/**` TypeScript diagnostics unrelated to these issue-template and public-readiness-test changes.
