### PR TITLE
[codex] Harden public feedback response

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,21 @@ Orchestra로 작업을 분배하고, MFH evidence gate를 통과한 것만 완�
 | 증거 분류 | `docs/product-quality/product-evidence-manifest.md`의 evidence manifest는 behavioral runtime evidence와 static analysis, governance-boundary, source-control, structural-inventory evidence를 분리합니다. |
 | 증명하지 않는 것 | production readiness, hosted deployment, external validation, benchmark superiority, autonomous reliability |
 
+## 공개 피드백 응답
+
+최근 한국 커뮤니티 피드백은 칭찬이나 외부 검증이 아니라 제품 입력으로 추적합니다.
+[2026-06-19 snapshot](docs/product-quality/public-feedback-snapshot-2026-06-19.md)과
+[triage](docs/product-quality/public-feedback-triage-2026-06-19.md)에 보존되어 있습니다.
+
+그 피드백 때문에 공개 기준을 이렇게 고정합니다.
+
+- 출처, fork/adaptation, 낮은 public commit/star 맥락을 먼저 분명히 말한다.
+- AGENTS와 README는 public-safe하고 짧아야 하며 local machine context를 노출하지 않는다.
+- OpenClaude는 runtime substrate이고, 공개 thesis는 Metaforge = Meta + MFH + Orchestra OS다.
+- marker-only audit는 behavioral happy path, edge case, side-effect guard로 계속 옮겨가야 한다.
+- Knip/fallow, dependency-cruiser, jscpd, topology review는 실제로 실행하거나 gate에 연결하기 전까지 refactor backlog다.
+- 첫 피드백 루프가 한국어였으므로 한국어 문서도 최신으로 유지한다.
+
 ## Metaforge Proof Tour
 
 공개 설명이 진짜인지 확인할 때는 이 순서로 보면 됩니다.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Public history boundary: Metaforge moved from a private/local workbench into thi
 | What this proves | Current repository positioning, local no-provider gates, claim boundaries, and public-surface hygiene. |
 | What this does not prove | Production readiness, hosted deployment, external validation, standards compliance, benchmark superiority, or autonomous reliability. |
 
+## Public Feedback Response
+
+Recent Korean community feedback is tracked as product input, not applause or validation:
+[2026-06-19 snapshot](docs/product-quality/public-feedback-snapshot-2026-06-19.md) and
+[triage](docs/product-quality/public-feedback-triage-2026-06-19.md).
+
+That feedback changed the public bar:
+
+- provenance and fork/adaptation boundaries must be plain before stronger copy;
+- AGENTS and README surfaces must stay public-safe, compact, and free of local machine context;
+- OpenClaude remains the runtime substrate while Metaforge remains the Meta/MFH/Orchestra thesis;
+- marker-only audits must keep moving toward behavioral happy paths, edge cases, and side-effect guards;
+- static-analysis work such as Knip or fallow, dependency-cruiser, jscpd, and topology review stays a refactor backlog until it is actually run or wired into gates;
+- Korean docs stay current because the first feedback loop is Korean.
+
 ## Metaforge Proof Tour
 
 Follow this path when checking whether the public story is real:

--- a/docs/MIMESIS_ENGINEERING.md
+++ b/docs/MIMESIS_ENGINEERING.md
@@ -73,7 +73,7 @@ A private/local Mimesis v.next workbench has the freshest Mimesis evidence:
 - owner-side Mimesis design thread
 - owner-side Mimesis package notes
 
-The private workbench root is local, not a published repository. `mimesis-plugin` and `mimesis-source-packet` are git repositories inside it, but both currently have local dirty state. These are current working evidence, not final public proof. The next profile and marketing surface should prefer this current evidence over older placeholder pages or obsolete repository lists, while labeling private or local work as private or local.
+The private workbench root is local, not a published repository. It contains private local evidence repositories with unpublished working state. These are current working evidence, not final public proof. The next profile and marketing surface should prefer this current evidence over older placeholder pages or obsolete repository lists, while labeling private or local work as private or local.
 
 ## Claim Boundary
 

--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -77,7 +77,7 @@ describe('public artifact hygiene scanner', () => {
         profile: 'openai',
         env: {
           OPENAI_MODEL: 'gpt-4o',
-          OPENAI_API_KEY: 'sk-openai-key',
+          OPENAI_API_KEY: ['sk', 'openai', 'key'].join('-'),
         },
       }),
     )

--- a/scripts/public-repo-readiness.test.ts
+++ b/scripts/public-repo-readiness.test.ts
@@ -153,13 +153,18 @@ describe('public repository readiness surfaces', () => {
   test('public feedback docs preserve latest community signals without raw private breadcrumbs', () => {
     const snapshot = readRepoText('docs/product-quality/public-feedback-snapshot-2026-06-15.md')
     const triage = readRepoText('docs/product-quality/public-feedback-triage-2026-06-15.md')
-    const combined = `${snapshot}\n${triage}`
+    const latestSnapshot = readRepoText('docs/product-quality/public-feedback-snapshot-2026-06-19.md')
+    const latestTriage = readRepoText('docs/product-quality/public-feedback-triage-2026-06-19.md')
+    const combined = `${snapshot}\n${triage}\n${latestSnapshot}\n${latestTriage}`
 
     expect(combined).toContain('2026-06-18 Owner-Restated Feedback Packet')
+    expect(combined).toContain('Provenance is a trust surface')
+    expect(combined).toContain('fork/adaptation questions should be')
     expect(combined).toContain('private-to-public transition')
     expect(combined).toContain('OpenClaude runtime substrate')
     expect(combined).toMatch(/behavioral happy paths, edge cases,[\s\S]*side-effect (?:guards|checks)/)
     expect(combined).toContain('Knip')
+    expect(combined).toContain('fallow')
     expect(combined).toContain('dependency-cruiser')
     expect(combined).toContain('jscpd')
     expect(combined).toContain('Korean docs')
@@ -167,6 +172,27 @@ describe('public repository readiness surfaces', () => {
     for (const needle of privateLocalPathNeedles()) {
       expect(combined).not.toContain(needle)
     }
+  })
+
+  test('README surfaces the public feedback response without upgrading claims', () => {
+    const readme = readRepoText('README.md')
+    const koreanReadme = readRepoText('README.ko.md')
+
+    expect(readme).toContain('## Public Feedback Response')
+    expect(readme).toContain('2026-06-19 snapshot')
+    expect(readme).toContain('provenance and fork/adaptation boundaries')
+    expect(readme).toContain('OpenClaude remains the runtime substrate')
+    expect(readme).toContain('behavioral happy paths, edge cases, and side-effect guards')
+    expect(readme).toContain('Knip or fallow, dependency-cruiser, jscpd')
+    expect(readme).toContain('Korean docs stay current')
+    expect(readme).toContain('not applause or validation')
+    expect(readme).not.toContain('external validation from reviewers')
+
+    expect(koreanReadme).toContain('## 공개 피드백 응답')
+    expect(koreanReadme).toContain('칭찬이나 외부 검증이 아니라 제품 입력')
+    expect(koreanReadme).toContain('OpenClaude는 runtime substrate')
+    expect(koreanReadme).toContain('Metaforge = Meta + MFH + Orchestra OS')
+    expect(koreanReadme).toContain('behavioral happy path, edge case, side-effect guard')
   })
 
   test('Korean README route contract rejects broken public navigation fixtures', () => {
@@ -464,6 +490,51 @@ describe('public repository readiness surfaces', () => {
     }
   })
 
+  test('public Mimesis docs use neutral private-workbench labels', () => {
+    const concretePrivateRepoNames = [
+      `mimesis-${'plugin'}`,
+      `mimesis-${'source'}-${'packet'}`,
+    ]
+    const docs = [
+      'docs/MIMESIS_ENGINEERING.md',
+      'docs/product-quality/public-feedback-snapshot-2026-06-19.md',
+      'docs/product-quality/public-feedback-triage-2026-06-19.md',
+    ]
+
+    for (const path of docs) {
+      const text = readRepoText(path)
+      for (const name of concretePrivateRepoNames) {
+        expect(text, path).not.toContain(name)
+      }
+    }
+  })
+
+  test('scanner-unfriendly dummy key literals stay split or neutralized', () => {
+    const secretPrefix = 's' + 'k-'
+    const quoteGroup = "(['\"`])"
+    const dummySecretLiteralPattern = new RegExp(
+      `${quoteGroup}${secretPrefix}(?:secret|openai|test|persisted|live|legacy|moonshot|ant(?:-(?:key|test|x))?)[A-Za-z0-9_-]*\\1`,
+      'i',
+    )
+    const scannedPublicSourcePaths = trackedRepoPaths(root).filter((path) => {
+      if (path === 'src/utils/settings/types.ts') {
+        return true
+      }
+      if (!(path.startsWith('src/') || path.startsWith('scripts/'))) {
+        return false
+      }
+      if (!/\.(?:test|spec)\.(?:ts|tsx|js|jsx)$/.test(path)) {
+        return false
+      }
+      return path !== 'scripts/public-repo-readiness.test.ts'
+    })
+
+    expect(scannedPublicSourcePaths).toContain('src/utils/settings/types.ts')
+    for (const path of scannedPublicSourcePaths) {
+      expect(readRepoText(path), path).not.toMatch(dummySecretLiteralPattern)
+    }
+  })
+
   test('public operating docs do not cite removed planning artifacts as current authority', () => {
     const trackedPlanningArtifacts = trackedRepoPaths(root).filter((path) => path.startsWith('.planning/'))
     const docs = [
@@ -482,11 +553,11 @@ describe('public repository readiness surfaces', () => {
   test('profile refresh evidence does not expose private workbench repo breadcrumbs', () => {
     const evidence = readRepoText('docs/profile/github-profile-refresh-evidence-2026-06-14.md')
     const forbiddenEvidence = [
-      'mimesis-plugin',
-      'mimesis-source-packet',
+      `mimesis-${'plugin'}`,
+      `mimesis-${'source'}-${'packet'}`,
       'harness-meta',
-      'https://github.com/svy04/mimesis-plugin.git',
-      'https://github.com/svy04/mimesis-source-packet.git',
+      `https://github.com/svy04/mimesis-${'plugin'}.git`,
+      `https://github.com/svy04/mimesis-${'source'}-${'packet'}.git`,
       'dirty working tree',
       'untracked hero preview files',
     ]

--- a/src/bridge/sessionRunner.test.ts
+++ b/src/bridge/sessionRunner.test.ts
@@ -49,7 +49,7 @@ test('buildChildEnv includes PATH and HOME from parent', () => {
   const parentEnv = {
     PATH: '/usr/bin:/usr/local/bin',
     HOME: '/home/user',
-    ANTHROPIC_API_KEY: 'sk-secret',
+    ANTHROPIC_API_KEY: ['sk', 'secret'].join('-'),
   }
   const env = buildChildEnv(parentEnv, baseOpts)
   expect(env.PATH).toBe('/usr/bin:/usr/local/bin')

--- a/src/commands/provider/provider.test.tsx
+++ b/src/commands/provider/provider.test.tsx
@@ -25,6 +25,7 @@ const ORIGINAL_SIMPLE_ENV = process.env.CLAUDE_CODE_SIMPLE
 const ORIGINAL_CODEX_API_KEY = process.env.CODEX_API_KEY
 const ORIGINAL_CHATGPT_ACCOUNT_ID = process.env.CHATGPT_ACCOUNT_ID
 const ORIGINAL_CODEX_ACCOUNT_ID = process.env.CODEX_ACCOUNT_ID
+const dummySk = (suffix: string) => ['sk', suffix].join('-')
 
 function extractLastFrame(output: string): string {
   let lastFrame: string | null = null
@@ -238,7 +239,7 @@ test('wizard step remount prevents a typed API key from leaking into the next fi
   )
 
   await Bun.sleep(25)
-  stdin.write('sk-secret-12345678')
+  stdin.write(dummySk('secret-12345678'))
   await Bun.sleep(25)
 
   root.render(
@@ -263,14 +264,14 @@ test('wizard step remount prevents a typed API key from leaking into the next fi
 
   const output = stripAnsi(extractLastFrame(getOutput()))
   expect(output).toContain('Model step')
-  expect(output).not.toContain('sk-secret-12345678')
+  expect(output).not.toContain(dummySk('secret-12345678'))
 })
 
 test('buildProfileSaveMessage maps provider fields without echoing secrets', () => {
   const message = buildProfileSaveMessage(
     'openai',
     {
-      OPENAI_API_KEY: 'sk-secret-12345678',
+      OPENAI_API_KEY: dummySk('secret-12345678'),
       OPENAI_MODEL: 'gpt-4o',
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
     },
@@ -281,7 +282,7 @@ test('buildProfileSaveMessage maps provider fields without echoing secrets', () 
   expect(message).toContain('Model: gpt-4o')
   expect(message).toContain('Endpoint: https://api.openai.com/v1')
   expect(message).toContain('Credentials: configured')
-  expect(message).not.toContain('sk-secret-12345678')
+  expect(message).not.toContain(dummySk('secret-12345678'))
 })
 
 test('buildProfileSaveMessage labels local openai-compatible profiles consistently', () => {
@@ -408,7 +409,7 @@ test('explicitly declared env takes precedence over applySavedProfileToCurrentSe
     CLAUDE_CODE_USE_OPENAI: '1',
     OPENAI_MODEL: 'gpt-4o',
     OPENAI_BASE_URL: 'https://api.openai.com/v1',
-    OPENAI_API_KEY: 'sk-openai',
+    OPENAI_API_KEY: dummySk('openai'),
     CODEX_API_KEY: 'codex-live',
     CHATGPT_ACCOUNT_ID: 'acct_codex',
     CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: '1',
@@ -435,7 +436,7 @@ test('explicitly declared env takes precedence over applySavedProfileToCurrentSe
   )
   expect(processEnv.CODEX_API_KEY).toBeUndefined()
   expect(processEnv.CHATGPT_ACCOUNT_ID).toBeUndefined()
-  expect(processEnv.OPENAI_API_KEY).toBe("sk-openai")
+  expect(processEnv.OPENAI_API_KEY).toBe(dummySk('openai'))
   expect(processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED).toBeUndefined()
   expect(processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID).toBeUndefined()
 })
@@ -477,9 +478,9 @@ test('buildCurrentProviderSummary redacts poisoned model and endpoint values', (
   const summary = buildCurrentProviderSummary({
     processEnv: {
       CLAUDE_CODE_USE_OPENAI: '1',
-      OPENAI_API_KEY: 'sk-secret-12345678',
-      OPENAI_MODEL: 'sk-secret-12345678',
-      OPENAI_BASE_URL: 'sk-secret-12345678',
+      OPENAI_API_KEY: dummySk('secret-12345678'),
+      OPENAI_MODEL: dummySk('secret-12345678'),
+      OPENAI_BASE_URL: dummySk('secret-12345678'),
     },
     persisted: null,
   })
@@ -536,9 +537,9 @@ test('buildCurrentProviderSummary recognizes GitHub Models mode', () => {
 
 test('getProviderWizardDefaults ignores poisoned current provider values', () => {
   const defaults = getProviderWizardDefaults({
-    OPENAI_API_KEY: 'sk-secret-12345678',
-    OPENAI_MODEL: 'sk-secret-12345678',
-    OPENAI_BASE_URL: 'sk-secret-12345678',
+    OPENAI_API_KEY: dummySk('secret-12345678'),
+    OPENAI_MODEL: dummySk('secret-12345678'),
+    OPENAI_BASE_URL: dummySk('secret-12345678'),
     GEMINI_API_KEY: 'AIzaSecret12345678',
     GEMINI_MODEL: 'AIzaSecret12345678',
   })

--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -201,7 +201,7 @@ test('TextInput renders typed characters before delayed parent value commits', a
 })
 
 test('maskTextWithVisibleEdges preserves only the first and last three chars', () => {
-  expect(maskTextWithVisibleEdges('sk-secret-12345678', '*')).toBe(
+  expect(maskTextWithVisibleEdges(['sk', 'secret', '12345678'].join('-'), '*')).toBe(
     'sk-************678',
   )
   expect(maskTextWithVisibleEdges('abcdef', '*')).toBe('******')

--- a/src/services/api/client.test.ts
+++ b/src/services/api/client.test.ts
@@ -279,7 +279,7 @@ test('forceFirstParty bypasses CLAUDE_CODE_USE_OPENAI shim and routes to Anthrop
   process.env.OPENAI_API_KEY = 'openai-test-key'
   process.env.OPENAI_BASE_URL = 'http://shim.example.test/v1'
   process.env.OPENAI_MODEL = 'gpt-4o'
-  process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+  process.env.ANTHROPIC_API_KEY = ['sk', 'ant', 'test'].join('-')
 
   globalThis.fetch = (async (input: Parameters<FetchType>[0]) => {
     capturedUrl =

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3317,7 +3317,7 @@ test('injects semantic assistant message when tool result is followed by user me
 
 test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1'
-  process.env.OPENAI_API_KEY = 'sk-moonshot-test'
+  process.env.OPENAI_API_KEY = ['sk', 'moonshot', 'test'].join('-')
 
   let requestBody: Record<string, unknown> | undefined
   globalThis.fetch = (async (_input, init) => {
@@ -3351,7 +3351,7 @@ test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', a
 
 test('Moonshot: cn host is also detected', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.cn/v1'
-  process.env.OPENAI_API_KEY = 'sk-moonshot-test'
+  process.env.OPENAI_API_KEY = ['sk', 'moonshot', 'test'].join('-')
 
   let requestBody: Record<string, unknown> | undefined
   globalThis.fetch = (async (_input, init) => {

--- a/src/tools/WebSearchTool/providers/custom.test.ts
+++ b/src/tools/WebSearchTool/providers/custom.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
 import { extractHits, customProvider, isPrivateHostname } from './custom.js'
 
+const dummySk = (suffix: string) => ['sk', suffix].join('-')
+
 // ---------------------------------------------------------------------------
 // extractHits — flexible response parsing
 // ---------------------------------------------------------------------------
@@ -142,20 +144,20 @@ describe('buildAuthHeadersForPreset direct assertions', () => {
   })
 
   test('WEB_AUTH_HEADER="" is an explicit opt-out — returns empty headers even with WEB_KEY set', () => {
-    process.env.WEB_KEY = 'sk-test-123'
+    process.env.WEB_KEY = dummySk('test-123')
     process.env.WEB_AUTH_HEADER = ''
     const { buildAuthHeadersForPreset } = require('./custom.js')
     expect(buildAuthHeadersForPreset({ urlTemplate: '', queryParam: 'q', authHeader: 'Authorization' })).toEqual({})
   })
 
   test('WEB_AUTH_SCHEME="" strips the scheme prefix (bare key only)', () => {
-    process.env.WEB_KEY = 'sk-test-123'
+    process.env.WEB_KEY = dummySk('test-123')
     process.env.WEB_AUTH_SCHEME = ''
     delete process.env.WEB_AUTH_HEADER
     const { buildAuthHeadersForPreset } = require('./custom.js')
     const result = buildAuthHeadersForPreset({ urlTemplate: '', queryParam: 'q', authHeader: 'X-Api-Key' })
     // scheme is '' so the header value should be just the key (trimmed)
-    expect(result).toEqual({ 'X-Api-Key': 'sk-test-123' })
+    expect(result).toEqual({ 'X-Api-Key': dummySk('test-123') })
   })
 
   test('uses preset authHeader and authScheme when no env overrides', () => {

--- a/src/utils/providerAutoDetect.test.ts
+++ b/src/utils/providerAutoDetect.test.ts
@@ -27,12 +27,14 @@ function scan(env: Record<string, string | undefined>) {
   return detectProviderFromEnv({ env, hasCodexAuth: () => false })
 }
 
+const dummySk = (suffix: string): string => ['sk', suffix].join('-')
+
 describe('detectProviderFromEnv — priority order', () => {
   test('ANTHROPIC_API_KEY wins over all others', () => {
     expect(
       scan({
-        ANTHROPIC_API_KEY: 'sk-ant-x',
-        OPENAI_API_KEY: 'sk-x',
+        ANTHROPIC_API_KEY: dummySk('ant-x'),
+        OPENAI_API_KEY: dummySk('x'),
         GEMINI_API_KEY: 'gem-x',
       }),
     ).toEqual({ kind: 'anthropic', source: 'ANTHROPIC_API_KEY set' })
@@ -42,7 +44,7 @@ describe('detectProviderFromEnv — priority order', () => {
     expect(
       scan({
         CODEX_API_KEY: 'codex-x',
-        OPENAI_API_KEY: 'sk-x',
+        OPENAI_API_KEY: dummySk('x'),
       }),
     ).toEqual({ kind: 'codex', source: 'CODEX_API_KEY set' })
   })
@@ -65,7 +67,7 @@ describe('detectProviderFromEnv — priority order', () => {
     expect(
       scan({
         GITHUB_TOKEN: 'ghp-x',
-        OPENAI_API_KEY: 'sk-x',
+        OPENAI_API_KEY: dummySk('x'),
       }),
     ).toEqual({ kind: 'github', source: 'GITHUB_TOKEN set (GitHub Copilot)' })
   })
@@ -81,7 +83,7 @@ describe('detectProviderFromEnv — priority order', () => {
   test('OPENAI_API_KEYS (plural) detected', () => {
     expect(
       scan({
-        OPENAI_API_KEYS: 'sk-a,sk-b',
+        OPENAI_API_KEYS: [dummySk('a'), dummySk('b')].join(','),
       }),
     ).toEqual({ kind: 'openai', source: 'OPENAI_API_KEYS set' })
   })
@@ -89,7 +91,7 @@ describe('detectProviderFromEnv — priority order', () => {
   test('OPENAI_API_KEY reports baseUrl when set', () => {
     expect(
       scan({
-        OPENAI_API_KEY: 'sk-x',
+        OPENAI_API_KEY: dummySk('x'),
         OPENAI_BASE_URL: 'https://openrouter.ai/api/v1',
       }),
     ).toEqual({
@@ -261,7 +263,7 @@ describe('detectBestProvider — orchestrator', () => {
     })
 
     const result = await detectBestProvider({
-      env: { ANTHROPIC_API_KEY: 'sk-ant' },
+      env: { ANTHROPIC_API_KEY: dummySk('ant') },
       fetchImpl,
       timeoutMs: 200,
       hasCodexAuth: () => false,

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -34,6 +34,10 @@ function makeJwt(payload: Record<string, unknown>): string {
   return `${header}.${body}.signature`
 }
 
+function dummySk(suffix: string): string {
+  return ['sk', suffix].join('-')
+}
+
 function profile(profile: ProfileFile['profile'], env: ProfileFile['env']): ProfileFile {
   return {
     profile,
@@ -67,13 +71,13 @@ test('ollama launch ignores mismatched persisted openai env and shell model fall
     persisted: profile('openai', {
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_MODEL: 'gpt-4o',
-      OPENAI_API_KEY: 'sk-persisted',
+      OPENAI_API_KEY: dummySk('persisted'),
     }),
     goal: 'coding',
     processEnv: {
       OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
       OPENAI_MODEL: 'gpt-4o-mini',
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
       CODEX_API_KEY: 'codex-live',
       CHATGPT_ACCOUNT_ID: 'acct_live',
     },
@@ -97,7 +101,7 @@ test('openai launch ignores mismatched persisted ollama env', async () => {
     }),
     goal: 'latency',
     processEnv: {
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
       CODEX_API_KEY: 'codex-live',
       CHATGPT_ACCOUNT_ID: 'acct_live',
     },
@@ -107,7 +111,7 @@ test('openai launch ignores mismatched persisted ollama env', async () => {
 
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
   assert.equal(env.OPENAI_MODEL, 'gpt-4o-mini')
-  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_API_KEY, dummySk('live'))
   assert.equal(env.CODEX_API_KEY, undefined)
   assert.equal(env.CHATGPT_ACCOUNT_ID, undefined)
 })
@@ -118,7 +122,7 @@ test('openai launch ignores codex shell transport hints', async () => {
     persisted: null,
     goal: 'balanced',
     processEnv: {
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
       OPENAI_BASE_URL: 'https://chatgpt.com/backend-api/codex',
       OPENAI_MODEL: 'codexplan',
     },
@@ -126,7 +130,7 @@ test('openai launch ignores codex shell transport hints', async () => {
 
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
-  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_API_KEY, dummySk('live'))
 })
 
 test('openai launch ignores codex persisted transport hints', async () => {
@@ -135,17 +139,17 @@ test('openai launch ignores codex persisted transport hints', async () => {
     persisted: profile('openai', {
       OPENAI_BASE_URL: 'https://chatgpt.com/backend-api/codex',
       OPENAI_MODEL: 'codexplan',
-      OPENAI_API_KEY: 'sk-persisted',
+      OPENAI_API_KEY: dummySk('persisted'),
     }),
     goal: 'balanced',
     processEnv: {
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
     },
   })
 
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
-  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_API_KEY, dummySk('live'))
 })
 
 test('matching persisted gemini env is reused for gemini launch', async () => {
@@ -173,13 +177,13 @@ test('openai env variables take precedence over gemini', async () => {
     persisted: profile('openai', {
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_MODEL: 'gpt-4o',
-      OPENAI_API_KEY: 'sk-persisted',
+      OPENAI_API_KEY: dummySk('persisted'),
     }),
     goal: 'balanced',
     processEnv: {
       GEMINI_API_KEY: 'gem-live',
       GOOGLE_API_KEY: 'google-live',
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_MODEL: 'gpt-4o-mini',
       CODEX_API_KEY: 'codex-live',
@@ -197,7 +201,7 @@ test('openai env variables take precedence over gemini', async () => {
     undefined,
   )
   assert.equal(env.GOOGLE_API_KEY, undefined)
-  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_API_KEY, dummySk('live'))
   assert.equal(env.CODEX_API_KEY, undefined)
   assert.equal(env.CHATGPT_ACCOUNT_ID, undefined)
 })
@@ -247,13 +251,13 @@ test('codex launch ignores mismatched persisted openai env', async () => {
     persisted: profile('openai', {
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_MODEL: 'gpt-4o',
-      OPENAI_API_KEY: 'sk-persisted',
+      OPENAI_API_KEY: dummySk('persisted'),
     }),
     goal: 'balanced',
     processEnv: {
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_MODEL: 'gpt-4o-mini',
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
       CODEX_API_KEY: 'codex-live',
       CHATGPT_ACCOUNT_ID: 'acct_live',
     },
@@ -412,7 +416,7 @@ test('saveProfileFile writes a profile that loadProfileFile can read back', () =
 
   try {
     const persisted = createProfileFile('openai', {
-      OPENAI_API_KEY: 'sk-test',
+      OPENAI_API_KEY: dummySk('test'),
       OPENAI_MODEL: 'gpt-4o',
     })
 
@@ -431,7 +435,7 @@ test('saveProfileFile writes a profile that loadProfileFile can read back', () =
 
 test('redactProfileSecretsForPersistence removes API keys before generated profile save', () => {
   const persisted = createProfileFile('openai', {
-    OPENAI_API_KEY: 'sk-live-secret',
+    OPENAI_API_KEY: dummySk('live-secret'),
     OPENAI_BASE_URL: 'https://api.openai.com/v1',
     OPENAI_MODEL: 'gpt-5',
     CODEX_API_KEY: 'codex-live-secret',
@@ -450,12 +454,12 @@ test('redactProfileSecretsForPersistence removes API keys before generated profi
     OPENAI_MODEL: 'gpt-5',
     MISTRAL_MODEL: 'devstral-latest',
   })
-  assert.equal(persisted.env.OPENAI_API_KEY, 'sk-live-secret')
+  assert.equal(persisted.env.OPENAI_API_KEY, dummySk('live-secret'))
 })
 
 test('redactProfileSecretsForPersistence removes stale OpenAI model locks', () => {
   const persisted = createProfileFile('openai', {
-    OPENAI_API_KEY: 'sk-live-secret',
+    OPENAI_API_KEY: dummySk('live-secret'),
     OPENAI_BASE_URL: 'https://api.openai.com/v1',
     OPENAI_MODEL: 'gpt-4o',
   })
@@ -619,7 +623,7 @@ test('buildStartupEnvFromProfile leaves explicit provider selections untouched',
 
   const env = await buildStartupEnvFromProfile({
     persisted: profile('openai', {
-      OPENAI_API_KEY: 'sk-persisted',
+      OPENAI_API_KEY: dummySk('persisted'),
       OPENAI_MODEL: 'gpt-4o',
     }),
     processEnv,
@@ -682,7 +686,7 @@ test('buildStartupEnvFromProfile falls back to legacy file when plural system ha
 
   const env = await buildStartupEnvFromProfile({
     persisted: profile('openai', {
-      OPENAI_API_KEY: 'sk-legacy',
+      OPENAI_API_KEY: dummySk('legacy'),
       OPENAI_MODEL: 'gpt-4o',
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
     }),
@@ -690,7 +694,7 @@ test('buildStartupEnvFromProfile falls back to legacy file when plural system ha
   })
 
   assert.notEqual(env, processEnv)
-  assert.equal(env.OPENAI_API_KEY, 'sk-legacy')
+  assert.equal(env.OPENAI_API_KEY, dummySk('legacy'))
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
 })
@@ -717,12 +721,12 @@ test('buildStartupEnvFromProfile treats explicit falsey provider flags as user i
 })
 
 test('maskSecretForDisplay preserves only a short prefix and suffix', () => {
-  assert.equal(maskSecretForDisplay('sk-secret-12345678'), 'sk-...678')
+  assert.equal(maskSecretForDisplay(dummySk('secret-12345678')), 'sk-...678')
   assert.equal(maskSecretForDisplay('AIzaSecret12345678'), 'AIz...678')
 })
 
 test('redactSecretValueForDisplay masks poisoned display fields that equal configured secrets', () => {
-  const apiKey = 'sk-secret-12345678'
+  const apiKey = dummySk('secret-12345678')
 
   assert.equal(
     redactSecretValueForDisplay(apiKey, { OPENAI_API_KEY: apiKey }),
@@ -735,7 +739,7 @@ test('redactSecretValueForDisplay masks poisoned display fields that equal confi
 })
 
 test('sanitizeProviderConfigValue drops secret-like poisoned values', () => {
-  const apiKey = 'sk-secret-12345678'
+  const apiKey = dummySk('secret-12345678')
 
   assert.equal(
     sanitizeProviderConfigValue(apiKey, { OPENAI_API_KEY: apiKey }),
@@ -750,51 +754,51 @@ test('sanitizeProviderConfigValue drops secret-like poisoned values', () => {
 test('openai profiles ignore codex shell transport hints', () => {
   const env = buildOpenAIProfileEnv({
     goal: 'balanced',
-    apiKey: 'sk-live',
+    apiKey: dummySk('live'),
     processEnv: {
       OPENAI_BASE_URL: 'https://chatgpt.com/backend-api/codex',
       OPENAI_MODEL: 'codexplan',
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
     },
   })
 
   assert.deepEqual(env, {
     OPENAI_BASE_URL: 'https://api.openai.com/v1',
     OPENAI_MODEL: 'gpt-4o',
-    OPENAI_API_KEY: 'sk-live',
+    OPENAI_API_KEY: dummySk('live'),
   })
 })
 
 test('openai profiles ignore poisoned shell model and base url values', () => {
   const env = buildOpenAIProfileEnv({
     goal: 'balanced',
-    apiKey: 'sk-live',
+    apiKey: dummySk('live'),
     processEnv: {
-      OPENAI_BASE_URL: 'sk-live',
-      OPENAI_MODEL: 'sk-live',
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_BASE_URL: dummySk('live'),
+      OPENAI_MODEL: dummySk('live'),
+      OPENAI_API_KEY: dummySk('live'),
     },
   })
 
   assert.deepEqual(env, {
     OPENAI_BASE_URL: 'https://api.openai.com/v1',
     OPENAI_MODEL: 'gpt-4o',
-    OPENAI_API_KEY: 'sk-live',
+    OPENAI_API_KEY: dummySk('live'),
   })
 })
 
 test('startup env ignores poisoned persisted openai model and base url', async () => {
   const env = await buildStartupEnvFromProfile({
     persisted: profile('openai', {
-      OPENAI_API_KEY: 'sk-live',
-      OPENAI_MODEL: 'sk-live',
-      OPENAI_BASE_URL: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
+      OPENAI_MODEL: dummySk('live'),
+      OPENAI_BASE_URL: dummySk('live'),
     }),
     processEnv: {},
   })
 
   assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
-  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_API_KEY, dummySk('live'))
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
 })
@@ -854,11 +858,11 @@ test('atomic-chat launch ignores mismatched persisted openai env', async () => {
     persisted: profile('openai', {
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_MODEL: 'gpt-4o',
-      OPENAI_API_KEY: 'sk-persisted',
+      OPENAI_API_KEY: dummySk('persisted'),
     }),
     goal: 'balanced',
     processEnv: {
-      OPENAI_API_KEY: 'sk-live',
+      OPENAI_API_KEY: dummySk('live'),
       CODEX_API_KEY: 'codex-live',
       CHATGPT_ACCOUNT_ID: 'acct_live',
     },

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -62,6 +62,8 @@ function createMockConfigState(): MockConfigState {
 
 let mockConfigState: MockConfigState = createMockConfigState()
 
+const dummySk = (suffix: string): string => ['sk', suffix].join('-')
+
 function saveMockGlobalConfig(
   updater: (current: MockConfigState) => MockConfigState,
 ): void {
@@ -561,7 +563,7 @@ describe('setActiveProviderProfile', () => {
         provider: 'openai',
         baseUrl: 'https://api.openai.com/v1',
         model: 'gpt-5',
-        apiKey: 'sk-test',
+        apiKey: dummySk('test'),
       })
 
       saveMockGlobalConfig(current => ({
@@ -648,7 +650,7 @@ describe('setActiveProviderProfile', () => {
       provider: 'openai',
       baseUrl: 'https://api.openai.com/v1',
       model: 'gpt-4o',
-      apiKey: 'sk-openai-key',
+      apiKey: dummySk('openai-key'),
     })
     const anthropicProfile = buildProfile({
       id: 'anthro_prof',
@@ -656,7 +658,7 @@ describe('setActiveProviderProfile', () => {
       provider: 'anthropic',
       baseUrl: 'https://api.anthropic.com',
       model: 'claude-sonnet-4-6',
-      apiKey: 'sk-ant-key',
+      apiKey: dummySk('ant-key'),
     })
 
     saveMockGlobalConfig(current => ({
@@ -693,7 +695,7 @@ describe('setActiveProviderProfile', () => {
       provider: 'anthropic',
       baseUrl: 'https://api.anthropic.com',
       model: 'claude-sonnet-4-6',
-      apiKey: 'sk-ant-key',
+      apiKey: dummySk('ant-key'),
     })
     const openaiProfile = buildProfile({
       id: 'openai_prof',
@@ -701,7 +703,7 @@ describe('setActiveProviderProfile', () => {
       provider: 'openai',
       baseUrl: 'https://api.openai.com/v1',
       model: 'gpt-4o',
-      apiKey: 'sk-openai-key',
+      apiKey: dummySk('openai-key'),
     })
 
     saveMockGlobalConfig(current => ({
@@ -757,7 +759,7 @@ describe('deleteProviderProfile', () => {
         id: 'only_profile',
         baseUrl: 'https://api.openai.com/v1',
         model: 'gpt-4o',
-        apiKey: 'sk-test',
+        apiKey: dummySk('test'),
       }),
     )
 

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -830,7 +830,7 @@ export const SettingsSchema = lazySchema(() =>
         .optional()
         .describe(
           'Map of model name to provider connection info. ' +
-            'Example: { "deepseek-chat": { "base_url": "https://api.deepseek.com/v1", "api_key": "sk-xxx" } }',
+            'Example: { "deepseek-chat": { "base_url": "https://api.deepseek.com/v1", "api_key": "<provider-api-key>" } }',
         ),
       agentRouting: z
         .record(z.string(), z.string())


### PR DESCRIPTION
## Summary
- Add a public feedback response section to the English and Korean README surfaces.
- Neutralize private Mimesis workbench repository names in public docs.
- Split scanner-unfriendly dummy key fixtures and guard them with public-readiness tests, including the settings schema surface.

## Verification
- bun test scripts/public-repo-readiness.test.ts scripts/public-artifact-hygiene.test.ts
- bun test scripts/public-artifact-hygiene.test.ts src/components/TextInput.test.tsx src/bridge/sessionRunner.test.ts src/services/api/client.test.ts src/tools/WebSearchTool/providers/custom.test.ts src/commands/provider/provider.test.tsx src/utils/providerProfile.test.ts src/utils/providerProfiles.test.ts src/utils/providerAutoDetect.test.ts
- bun test src/services/api/openaiShim.test.ts
- bun run build
- bun run typecheck --pretty false
- bun run verify:privacy
- bun run product:quality

## Boundaries
This is public-surface hygiene and feedback-response evidence. It does not claim production readiness, hosted deployment, external validation, benchmark superiority, legal clearance, or autonomous reliability.