### PR TITLE
Make native installer placeholder creation atomic

### DIFF
--- a/src/utils/nativeInstaller/installer.ts
+++ b/src/utils/nativeInstaller/installer.ts
@@ -163,16 +163,26 @@ async function getVersionPaths(version: string) {
 
   const installPath = join(dirs.versions, version)
 
-  // Create an empty file if it doesn't exist
-  try {
-    await stat(installPath)
-  } catch {
-    await writeFile(installPath, '', { encoding: 'utf8' })
-  }
+  await ensureVersionPlaceholderFile(installPath)
 
   return {
     stagingPath: join(dirs.staging, version),
     installPath,
+  }
+}
+
+export async function ensureVersionPlaceholderFile(filePath: string): Promise<void> {
+  try {
+    await writeFile(filePath, '', { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+  } catch (error: unknown) {
+    const code = getErrnoCode(error)
+    if (code === 'EEXIST') {
+      const existing = await stat(filePath)
+      if (existing.isFile()) {
+        return
+      }
+    }
+    throw error
   }
 }
 

--- a/src/utils/openclaudeInstallSurfaces.test.ts
+++ b/src/utils/openclaudeInstallSurfaces.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, expect, mock, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { homedir } from 'os'
 import { join } from 'path'
 
@@ -6,6 +8,7 @@ import * as actualEnvModule from './env.js'
 
 const originalEnv = { ...process.env }
 const originalMacro = (globalThis as Record<string, unknown>).MACRO
+const tempDirs: string[] = []
 
 function restoreProcessEnv(): void {
   for (const key of Object.keys(process.env)) {
@@ -14,11 +17,18 @@ function restoreProcessEnv(): void {
   Object.assign(process.env, originalEnv)
 }
 
-afterEach(() => {
+afterEach(async () => {
   restoreProcessEnv()
   ;(globalThis as Record<string, unknown>).MACRO = originalMacro
   mock.restore()
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-native-installer-'))
+  tempDirs.push(dir)
+  return dir
+}
 
 async function importFreshInstallCommand() {
   return import(`../commands/install.tsx?ts=${Date.now()}-${Math.random()}`)
@@ -70,4 +80,24 @@ test('cleanupNpmInstallations removes both openclaude and legacy claude local in
 
   expect(removedPaths).toContain(join(homedir(), '.openclaude', 'local'))
   expect(removedPaths).toContain(join(homedir(), '.claude', 'local'))
+})
+
+test('native installer creates version placeholder atomically without clobbering existing files', async () => {
+  const root = await makeTempDir()
+  const missingPath = join(root, 'missing-version')
+  const existingPath = join(root, 'existing-version')
+  const collidingDirectory = join(root, 'directory-version')
+
+  await writeFile(existingPath, 'already installed', 'utf8')
+  await mkdir(collidingDirectory)
+
+  const { ensureVersionPlaceholderFile } = await importFreshInstaller()
+
+  await ensureVersionPlaceholderFile(missingPath)
+  await expect(readFile(missingPath, 'utf8')).resolves.toBe('')
+
+  await ensureVersionPlaceholderFile(existingPath)
+  await expect(readFile(existingPath, 'utf8')).resolves.toBe('already installed')
+
+  await expect(ensureVersionPlaceholderFile(collidingDirectory)).rejects.toThrow()
 })


### PR DESCRIPTION
## Summary
- Replace the native installer version placeholder check-then-create path with exclusive file creation.
- Preserve existing placeholder files without truncating them and reject directory collisions.
- Add a regression test for missing, existing, and colliding placeholder paths.

## Evidence
- `bun test src/utils/openclaudeInstallSurfaces.test.ts`
- `bun run typecheck --pretty false`
- `bun run build`
- `bun run verify:privacy`
- `bun run product:quality`

## Claim boundary
This is a local remediation for the CodeQL file-system race pattern and is expected to address hosted alert #53 after GitHub analyzes this branch. Hosted alert closure is not claimed until CodeQL reports it on GitHub.