### PR TITLE
Complete markdown table escaping in cross review output

### DIFF
--- a/src/services/orchestra/crossReview.test.ts
+++ b/src/services/orchestra/crossReview.test.ts
@@ -146,4 +146,24 @@ describe('crossReview — formatting helpers', () => {
       expect(detail).toContain(v.rationale)
     }
   })
+
+  test('formatMatrixDetail escapes backslashes before markdown table pipes', () => {
+    const detail = formatMatrixDetail({
+      candidates: [baseCandidates[0]],
+      generatedAt: '2026-06-19T00:00:00.000Z',
+      verdicts: [
+        {
+          candidateLabel: 'gpt-a',
+          reviewer: 'gpt',
+          verdict: 'green',
+          scoresOutOf5: { correctness: 4, minimality: 4, scopeFit: 4 },
+          rationale: String.raw`windows path C:\tmp | table pipe`,
+        },
+      ],
+    })
+
+    expect(detail).toContain(
+      String.raw`| gpt-a | gpt | green | 4 | 4 | 4 | windows path C:\\tmp \| table pipe |`,
+    )
+  })
 })

--- a/src/services/orchestra/crossReview.ts
+++ b/src/services/orchestra/crossReview.ts
@@ -129,6 +129,10 @@ export function formatMatrixSummary(matrix: CrossReviewMatrix): string {
   return `[Phase 3 Cross-Review] ${parts.join(' | ')}`
 }
 
+function escapeMarkdownTableCell(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
+}
+
 export function formatMatrixDetail(matrix: CrossReviewMatrix): string {
   const lines: string[] = []
   lines.push(`# Phase 3 Cross-Review Matrix`)
@@ -139,7 +143,7 @@ export function formatMatrixDetail(matrix: CrossReviewMatrix): string {
   for (const v of matrix.verdicts) {
     const s = v.scoresOutOf5
     lines.push(
-      `| ${v.candidateLabel} | ${v.reviewer} | ${v.verdict} | ${s.correctness} | ${s.minimality} | ${s.scopeFit} | ${v.rationale.replace(/\|/g, '\\|')} |`,
+      `| ${v.candidateLabel} | ${v.reviewer} | ${v.verdict} | ${s.correctness} | ${s.minimality} | ${s.scopeFit} | ${escapeMarkdownTableCell(v.rationale)} |`,
     )
   }
   lines.push('')


### PR DESCRIPTION
## Summary
- Escape backslashes before markdown table pipes in Orchestra cross-review rationale cells.
- Add a regression test for Windows-style paths plus pipe characters in the rendered matrix.

## Verification
- RED: `bun test src/services/orchestra/crossReview.test.ts` failed before the implementation on the new backslash+pipe expectation.
- GREEN: `bun test src/services/orchestra/crossReview.test.ts`
- `bun run typecheck --pretty false` (rerun alone after build completed)
- `bun run build`
- `bun run verify:privacy`
- `bun run product:quality`

## Claim boundary
This targets the CodeQL `js/incomplete-sanitization` pattern for markdown table escaping. Hosted alert closure is not claimed until GitHub CodeQL reports it on this branch or main.

Source: https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization/