### PR TITLE
[codex] Tighten Codex endpoint host detection

### DIFF
--- a/vscode-extension/openclaude-vscode/src/state.js
+++ b/vscode-extension/openclaude-vscode/src/state.js
@@ -239,7 +239,13 @@ function hasCodexBaseUrl(baseUrl) {
     return false;
   }
 
-  return /chatgpt\.com\/backend-api\/codex/i.test(normalized);
+  try {
+    const parsedUrl = new URL(normalized);
+    const pathname = parsedUrl.pathname.replace(/\/+$/, '').toLowerCase();
+    return parsedUrl.hostname.toLowerCase() === 'chatgpt.com' && pathname === '/backend-api/codex';
+  } catch {
+    return false;
+  }
 }
 
 function hasCodexAlias(model) {

--- a/vscode-extension/openclaude-vscode/src/state.test.js
+++ b/vscode-extension/openclaude-vscode/src/state.test.js
@@ -196,6 +196,44 @@ test('describeProviderState reports OpenAI when the parsed host is api.openai.co
   );
 });
 
+test('describeProviderState does not treat substring-matched Codex endpoints as Codex', () => {
+  assert.deepEqual(
+    describeProviderState({
+      shimEnabled: false,
+      env: {
+        CLAUDE_CODE_USE_OPENAI: '1',
+        OPENAI_BASE_URL: 'https://evil.example/path/chatgpt.com/backend-api/codex',
+        OPENAI_MODEL: 'gpt-5.4',
+      },
+      profile: null,
+    }),
+    {
+      label: 'OpenAI-compatible',
+      detail: 'gpt-5.4',
+      source: 'env',
+    },
+  );
+});
+
+test('describeProviderState reports Codex only for the parsed ChatGPT Codex endpoint', () => {
+  assert.deepEqual(
+    describeProviderState({
+      shimEnabled: false,
+      env: {
+        CLAUDE_CODE_USE_OPENAI: '1',
+        OPENAI_BASE_URL: 'https://chatgpt.com/backend-api/codex',
+        OPENAI_MODEL: 'gpt-5.4',
+      },
+      profile: null,
+    }),
+    {
+      label: 'Codex',
+      detail: 'gpt-5.4',
+      source: 'env',
+    },
+  );
+});
+
 test('describeProviderState reports environment-backed provider details', () => {
   assert.deepEqual(
     describeProviderState({


### PR DESCRIPTION
## What changed

- Replaced the legacy VS Code extension Codex endpoint substring regex with URL parsing.
- Codex provider labeling now requires `hostname === chatgpt.com` and normalized path `/backend-api/codex`.
- Added regression coverage for a hostile URL that only contains `chatgpt.com/backend-api/codex` in its path, plus the positive parsed ChatGPT Codex endpoint case.

## Why

CodeQL flagged the previous check as a missing regexp anchor risk. The root cause was that provider labeling tested the entire URL string for a substring, so an unrelated host could be labeled as Codex if its path contained the ChatGPT Codex endpoint text.

## Impact

This narrows the legacy extension provider label to the parsed host/path boundary without changing model-alias based Codex detection.

## Verification

- RED before fix: `node --test vscode-extension/openclaude-vscode/src/state.test.js` failed on the new substring Codex endpoint test.
- GREEN after fix: `node --test vscode-extension/openclaude-vscode/src/state.test.js` passed, 18/18.
- `bun test src/state.test.js src/presentation.test.js src/extension.test.js` from `vscode-extension/openclaude-vscode` passed, 41/41.
- `bun run typecheck --pretty false` passed.
- `bun run build` passed.
- `bun run verify:privacy` passed.
- `bun run product:quality` passed; terminal condition remains the existing local VS Code CLI availability boundary.
- `git diff --check` passed.

Known unrelated boundary: `npm test` in `vscode-extension/openclaude-vscode` currently fails because the package script uses `node --test ./src/*.test.js` while `src/extension.test.js` imports `bun:test` for `mock.module`. The equivalent Bun command above passed.