### PR TITLE
[codex] Sanitize plain text log output

### DIFF
--- a/src/cli/exit.test.ts
+++ b/src/cli/exit.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { cliError } from './exit.ts'
+
+test('cliError writes user-controlled errors as a single log line', () => {
+  const originalConsoleError = console.error
+  const originalExit = process.exit
+  const logged: unknown[][] = []
+  let exitCode: string | number | null | undefined
+
+  console.error = (...args: unknown[]) => {
+    logged.push(args)
+  }
+  process.exit = ((code?: string | number | null | undefined) => {
+    exitCode = code
+    return undefined as never
+  }) as typeof process.exit
+
+  try {
+    cliError('invalid name\r\n[INFO] forged entry\u001b[31m')
+  } finally {
+    console.error = originalConsoleError
+    process.exit = originalExit
+  }
+
+  assert.equal(exitCode, 1)
+  assert.equal(logged.length, 1)
+  assert.equal(logged[0]?.length, 1)
+  const message = String(logged[0]?.[0])
+  assert.equal(message.includes('\r'), false)
+  assert.equal(message.includes('\n'), false)
+  assert.equal(message.includes('\u001b'), false)
+  assert.match(message, /^invalid name \[INFO\] forged entry\[31m$/)
+})

--- a/src/cli/exit.ts
+++ b/src/cli/exit.ts
@@ -8,6 +8,8 @@
  */
 /* eslint-disable custom-rules/no-process-exit -- centralized CLI exit point */
 
+import { sanitizePlainTextLogValue } from '../utils/logSanitization.js'
+
 // `return undefined as never` (not a post-exit throw) — tests spy on
 // process.exit and let it return. Call sites write `return cliError(...)`
 // where subsequent code would dereference narrowed-away values under mock.
@@ -18,7 +20,7 @@
 /** Write an error message to stderr (if given) and exit with code 1. */
 export function cliError(msg?: string): never {
   // biome-ignore lint/suspicious/noConsole: centralized CLI error output
-  if (msg) console.error(msg)
+  if (msg) console.error(sanitizePlainTextLogValue(msg))
   process.exit(1)
   return undefined as never
 }

--- a/src/utils/claudeInChrome/chromeNativeHost.test.ts
+++ b/src/utils/claudeInChrome/chromeNativeHost.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { formatChromeNativeHostLogLine } from './chromeNativeHost.ts'
+
+test('formatChromeNativeHostLogLine keeps message and args on one log line', () => {
+  const line = formatChromeNativeHostLogLine('socket\r\n[INFO] forged', [
+    'arg\nnext',
+    { reason: 'bad\rvalue' },
+    new Error('boom\nagain'),
+  ])
+
+  assert.equal(line.includes('\r'), false)
+  assert.equal(line.includes('\n'), false)
+  assert.match(line, /^\[Claude Chrome Native Host\] socket \[INFO\] forged /)
+  assert.match(line, /arg next/)
+  assert.match(line, /bad value/)
+  assert.match(line, /boom again/)
+})

--- a/src/utils/claudeInChrome/chromeNativeHost.ts
+++ b/src/utils/claudeInChrome/chromeNativeHost.ts
@@ -20,6 +20,7 @@ import { homedir, platform } from 'os'
 import { join } from 'path'
 import { z } from 'zod'
 import { lazySchema } from '../lazySchema.js'
+import { sanitizePlainTextLogValue } from '../logSanitization.js'
 import { jsonParse, jsonStringify } from '../slowOperations.js'
 import { getSecureSocketPath, getSocketDir } from './common.js'
 
@@ -31,18 +32,28 @@ const LOG_FILE =
     ? join(homedir(), '.claude', 'debug', 'chrome-native-host.txt')
     : undefined
 
+export function formatChromeNativeHostLogLine(
+  message: string,
+  args: unknown[] = [],
+): string {
+  const safeMessage = sanitizePlainTextLogValue(message)
+  const formattedArgs =
+    args.length > 0 ? ` ${sanitizePlainTextLogValue(args)}` : ''
+  return `[Claude Chrome Native Host] ${safeMessage}${formattedArgs}`
+}
+
 function log(message: string, ...args: unknown[]): void {
+  const formattedMessage = formatChromeNativeHostLogLine(message, args)
   if (LOG_FILE) {
     const timestamp = new Date().toISOString()
-    const formattedArgs = args.length > 0 ? ' ' + jsonStringify(args) : ''
-    const logLine = `[${timestamp}] [Claude Chrome Native Host] ${message}${formattedArgs}\n`
+    const logLine = `[${timestamp}] ${formattedMessage}\n`
     // Fire-and-forget: logging is best-effort and callers (including event
     // handlers) don't await
     void appendFile(LOG_FILE, logLine).catch(() => {
       // Ignore file write errors
     })
   }
-  console.error(`[Claude Chrome Native Host] ${message}`, ...args)
+  console.error(formattedMessage)
 }
 /**
  * Send a message to stdout (Chrome native messaging protocol)

--- a/src/utils/logSanitization.ts
+++ b/src/utils/logSanitization.ts
@@ -1,0 +1,29 @@
+function stringifyForLog(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (value instanceof Error) {
+    return value.message
+  }
+
+  try {
+    const serialized = JSON.stringify(value, (_key, nestedValue: unknown) => {
+      if (nestedValue instanceof Error) {
+        return sanitizePlainTextLogValue(nestedValue.message)
+      }
+      return typeof nestedValue === 'string'
+        ? sanitizePlainTextLogValue(nestedValue)
+        : nestedValue
+    })
+    return serialized ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+export function sanitizePlainTextLogValue(value: unknown): string {
+  return stringifyForLog(value)
+    .replace(/[\r\n\u0085\u2028\u2029]+/g, ' ')
+    .replace(/\t+/g, ' ')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+}


### PR DESCRIPTION
﻿## Summary
- Add a shared plain-text log sanitizer for CLI/native-host stderr output.
- Sanitize `cliError` output and Chrome native host formatted log lines so CR/LF and control characters cannot forge additional log entries.
- Add focused regression tests for user-controlled CLI errors and Chrome native host log args, including nested `Error` values.

## Source basis
- CodeQL `js/log-injection`: plain-text logs should remove line breaks from user input and mark user-controlled content clearly.
- OWASP Logging Cheat Sheet: sanitize CR/LF and delimiters before writing event data to logs.
- CWE-117: log output must neutralize CR/LF/control characters to prevent forged entries.

## Verification
- `bun test src/cli/exit.test.ts src/utils/claudeInChrome/chromeNativeHost.test.ts`
- `bun run typecheck --pretty false`
- `bun run build`
- `bun run verify:privacy`
- `bun run product:quality`

`product:quality` completed with the known local boundary: `PRODUCT_QUALITY_GATE_BLOCKED_BY_LOCAL_VSCODE_CLI_UNAVAILABLE`. This PR does not claim hosted CodeQL closure until the GitHub run reports it.
