### PR TITLE
Remove CodeQL directive and mock dead branches

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -191,10 +191,8 @@ export function StreamingMarkdown({
   // React Compiler: this component reads and writes stablePrefixRef.current
   // during render by design. The boundary only advances (monotonic), so
   // the ref mutation is idempotent under StrictMode double-render — but the
-  // compiler can't prove that, and memoizing around the ref reads would
-  // break the algorithm (stale boundary). Opt out.
-  // codeql[js/unknown-directive]
-  'use no memo';
+  // compiler can't prove that. This checked-in file already contains compiler
+  // output, so keep the opt-out rationale here without a runtime directive.
 
   configureMarked();
 

--- a/src/components/OffscreenFreeze.tsx
+++ b/src/components/OffscreenFreeze.tsx
@@ -24,9 +24,8 @@ export function OffscreenFreeze({
   children
 }: Props): React.ReactNode {
   // React Compiler: reading cached.current in the return is the entire
-  // freeze mechanism — memoizing this component would defeat it. Opt out.
-  // codeql[js/unknown-directive]
-  'use no memo';
+  // freeze mechanism. This checked-in file already contains compiler output,
+  // so keep the opt-out rationale here without a runtime directive.
 
   const inVirtualList = useContext(InVirtualListContext);
   const [ref, {

--- a/src/services/rateLimitMocking.ts
+++ b/src/services/rateLimitMocking.ts
@@ -6,10 +6,8 @@
 import { APIError } from '@anthropic-ai/sdk'
 import {
   applyMockHeaders,
-  checkMockFastModeRateLimit,
   getMockHeaderless429Message,
   getMockHeaders,
-  isMockFastModeRateLimitScenario,
   shouldProcessMockLimits,
 } from './mockRateLimits.js'
 
@@ -47,7 +45,7 @@ export function shouldProcessRateLimits(isSubscriber: boolean): boolean {
  */
 export function checkMockRateLimitError(
   currentModel: string,
-  isFastModeActive?: boolean,
+  _isFastModeActive?: boolean,
 ): APIError | null {
   if (!shouldProcessMockLimits()) {
     return null
@@ -90,23 +88,6 @@ export function checkMockRateLimitError(
   // This simulates the real API behavior where fallback to Sonnet succeeds
   if (isOpusLimit && !isUsingOpus) {
     return null
-  }
-
-  // Check for mock fast mode rate limits (handles expiry, countdown, etc.)
-  if (isMockFastModeRateLimitScenario()) {
-    const fastModeHeaders = checkMockFastModeRateLimit(isFastModeActive)
-    if (fastModeHeaders === null) {
-      return null
-    }
-    // Create a mock 429 error with the fast mode headers
-    const error = new APIError(
-      429,
-      { error: { type: 'rate_limit_error', message: 'Rate limit exceeded' } },
-      'Rate limit exceeded',
-      // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-      new globalThis.Headers(toDefinedHeaderEntries(fastModeHeaders)),
-    )
-    return error
   }
 
   const shouldThrow429 =


### PR DESCRIPTION
## Summary
- remove runtime `use no memo` directive statements from checked-in React Compiler output files
- keep the React Compiler rationale as comments without triggering CodeQL `js/unknown-directive`
- remove the external no-op fast-mode mock branch that CodeQL reports as defensive dead code

## Verification
- `bun test src/services/api/withRetry.test.ts`
- `bun run typecheck --pretty false`
- `bun run build`
- `bun run verify:privacy`
- `bun run product:quality`
- `git diff --check`

## Boundaries
- This is a public-surface cleanup only; no production, release, benchmark, or external validation claim is added.
- Default-branch CodeQL alert closure must be confirmed after merge and hosted CodeQL completion.