### PR TITLE
[codex] Clean up CodeQL capability guard alerts

### DIFF
--- a/src/commands/plugin/ValidatePlugin.tsx
+++ b/src/commands/plugin/ValidatePlugin.tsx
@@ -26,44 +26,33 @@ export function ValidatePlugin(t0: Props) {
           onComplete("Usage: /plugin validate <path>\n\nValidate a plugin or marketplace manifest file or directory.\n\nExamples:\n  /plugin validate .claude-plugin/plugin.json\n  /plugin validate /path/to/plugin-directory\n  /plugin validate .\n\nWhen given a directory, automatically validates .claude-plugin/marketplace.json\nor .claude-plugin/plugin.json (prefers marketplace if both exist).\n\nOr from the command line:\n  claude plugin validate <path>");
           return;
         }
-        ;
         try {
           const result = await validateManifest(path);
           let output = "";
           output = output + `Validating ${result.fileType} manifest: ${result.filePath}\n\n`;
-          output;
           if (result.errors.length > 0) {
             output = output + `${figures.cross} Found ${result.errors.length} ${plural(result.errors.length, "error")}:\n\n`;
-            output;
             result.errors.forEach(error_0 => {
               output = output + `  ${figures.pointer} ${error_0.path}: ${error_0.message}\n`;
-              output;
             });
             output = output + "\n";
-            output;
           }
           if (result.warnings.length > 0) {
             output = output + `${figures.warning} Found ${result.warnings.length} ${plural(result.warnings.length, "warning")}:\n\n`;
-            output;
             result.warnings.forEach(warning => {
               output = output + `  ${figures.pointer} ${warning.path}: ${warning.message}\n`;
-              output;
             });
             output = output + "\n";
-            output;
           }
           if (result.success) {
             if (result.warnings.length > 0) {
               output = output + `${figures.tick} Validation passed with warnings\n`;
-              output;
             } else {
               output = output + `${figures.tick} Validation passed\n`;
-              output;
             }
             process.exitCode = 0;
           } else {
             output = output + `${figures.cross} Validation failed\n`;
-            output;
             process.exitCode = 1;
           }
           onComplete(output);

--- a/src/components/GlobalSearchDialog.tsx
+++ b/src/components/GlobalSearchDialog.tsx
@@ -290,7 +290,6 @@ function _temp4(query_0: string, controller_1: AbortController, setMatches_0: Di
       return;
     }
     collected = collected + parsed.length;
-    collected;
     setMatches_0((prev: Match[]) => {
       const seen = new Set(prev.map(matchKey));
       const fresh = parsed.filter(p => !seen.has(matchKey(p)));

--- a/src/utils/context.modelCapability.test.ts
+++ b/src/utils/context.modelCapability.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, expect, mock, test } from 'bun:test'
+
+type CapabilityLike = {
+  max_input_tokens?: number
+  max_tokens?: number
+}
+
+const originalEnv = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
+  USER_TYPE: process.env.USER_TYPE,
+}
+
+let capabilityForModel: (_model: string) => CapabilityLike | undefined = () =>
+  undefined
+let importCounter = 0
+
+mock.module('./model/modelCapabilities.js', () => ({
+  getModelCapability: (model: string) => capabilityForModel(model),
+  refreshModelCapabilities: async () => {},
+}))
+
+afterEach(() => {
+  capabilityForModel = () => undefined
+  restoreEnv('CLAUDE_CODE_USE_OPENAI')
+  restoreEnv('CLAUDE_CODE_USE_GEMINI')
+  restoreEnv('CLAUDE_CODE_USE_GITHUB')
+  restoreEnv('CLAUDE_CODE_USE_MISTRAL')
+  restoreEnv('USER_TYPE')
+})
+
+function restoreEnv(name: keyof typeof originalEnv): void {
+  const value = originalEnv[name]
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
+
+function clearProviderEnv(): void {
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.USER_TYPE
+}
+
+async function importFreshContext() {
+  importCounter += 1
+  return import(`./context.ts?model-capability-${importCounter}`)
+}
+
+test('getContextWindowForModel snapshots model capability input tokens before comparing', async () => {
+  clearProviderEnv()
+  let reads = 0
+  capabilityForModel = () => ({
+    get max_input_tokens() {
+      reads += 1
+      if (reads > 1) {
+        throw new Error('max_input_tokens should only be read once')
+      }
+      return 250_000
+    },
+  })
+
+  const { getContextWindowForModel } = await importFreshContext()
+
+  expect(getContextWindowForModel('capability-model')).toBe(250_000)
+  expect(reads).toBe(1)
+})
+
+test('getModelMaxOutputTokens snapshots model capability output tokens before comparing', async () => {
+  clearProviderEnv()
+  let reads = 0
+  capabilityForModel = () => ({
+    get max_tokens() {
+      reads += 1
+      if (reads > 1) {
+        throw new Error('max_tokens should only be read once')
+      }
+      return 96_000
+    },
+  })
+
+  const { getModelMaxOutputTokens } = await importFreshContext()
+
+  expect(getModelMaxOutputTokens('capability-model')).toEqual({
+    default: 32_000,
+    upperLimit: 96_000,
+  })
+  expect(reads).toBe(1)
+})

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -103,15 +103,15 @@ export function getContextWindowForModel(
     return OPENAI_FALLBACK_CONTEXT_WINDOW
   }
 
-  const cap = getModelCapability(model)
-  if (cap?.max_input_tokens && cap.max_input_tokens >= 100_000) {
+  const maxInputTokens = getModelCapability(model)?.max_input_tokens
+  if (typeof maxInputTokens === 'number' && maxInputTokens >= 100_000) {
     if (
-      cap.max_input_tokens > MODEL_CONTEXT_WINDOW_DEFAULT &&
+      maxInputTokens > MODEL_CONTEXT_WINDOW_DEFAULT &&
       is1mContextDisabled()
     ) {
       return MODEL_CONTEXT_WINDOW_DEFAULT
     }
-    return cap.max_input_tokens
+    return maxInputTokens
   }
 
   if (betas?.includes(CONTEXT_1M_BETA_HEADER) && modelSupports1M(model)) {
@@ -245,9 +245,9 @@ export function getModelMaxOutputTokens(model: string): {
     upperLimit = MAX_OUTPUT_TOKENS_UPPER_LIMIT
   }
 
-  const cap = getModelCapability(model)
-  if (cap?.max_tokens && cap.max_tokens >= 4_096) {
-    upperLimit = cap.max_tokens
+  const maxTokens = getModelCapability(model)?.max_tokens
+  if (typeof maxTokens === 'number' && maxTokens >= 4_096) {
+    upperLimit = maxTokens
     defaultTokens = Math.min(defaultTokens, upperLimit)
   }
 


### PR DESCRIPTION
## Summary

- Removes remaining generated no-op expression statements in `ValidatePlugin` and `GlobalSearchDialog`.
- Reworks model capability reads in `context.ts` so CodeQL sees a single guarded numeric snapshot before comparisons and returns.
- Adds a focused regression test proving capability token values are read once before being used.

## Why

GitHub CodeQL still reports the next open cleanup slice as `js/useless-expression` and `js/property-access-on-non-object` around these files. The UI/plugin changes are deletion-only no-op cleanup. The context change preserves the existing capability extension point while making the runtime guard and static-analysis shape explicit.

## Validation

- `bun test src/utils/context.modelCapability.test.ts src/utils/context.test.ts`
- `bun run typecheck --pretty false`
- `bun run build`
- `bun run verify:privacy`
- `bun run product:quality`
- `git diff --cached --check`

Note: local `product:quality` exited 0 and records the existing local VS Code CLI unavailable boundary as a product-quality terminal condition, not a new readiness claim.