### PR TITLE
Bound Claude model wording to configured routes

### DIFF
--- a/docs/product-quality/public-claim-boundary-report.json
+++ b/docs/product-quality/public-claim-boundary-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-19T08:46:53.468Z",
+  "generatedAt": "2026-06-19T10:06:56.453Z",
   "mode": "local_no_provider_public_claim_boundary",
   "primarySourceInputs": [
     {
@@ -1179,7 +1179,7 @@
     {
       "path": "docs/product-quality/dead-export-candidates-report.md",
       "exists": true,
-      "sha256": "dc08c5f4efa61cfb0e8b56df2ec102785dda21630d6efd8c34e814179ac83d4b",
+      "sha256": "25d160540f8856538f10c6607483498579c6bfcff49639e192a231970bc9ec36",
       "sizeBytes": 9104,
       "lineCount": 112
     },
@@ -1711,7 +1711,7 @@
     {
       "path": "docs/product-quality/script-duplication-audit-report.md",
       "exists": true,
-      "sha256": "939333855e57512209bd7ba58d4c9f724feb3bd277eb1ac6ffcdd26c211bfa30",
+      "sha256": "0baf5d2390b4348147afb5080b4dfd78ea50b7007a6cde7fdef1e4e2d5d1d1e0",
       "sizeBytes": 8700,
       "lineCount": 97
     },

--- a/docs/product-quality/public-claim-boundary-report.md
+++ b/docs/product-quality/public-claim-boundary-report.md
@@ -285,7 +285,7 @@ This map binds public Metaforge symbols to local evidence, allowed claims, expli
 | `docs/product-quality/community-intake-quality-report.md` | `true` | `e57c131467cd7c49c562c002ee3969d37dca82db8301ad2a25bbcf26793c1047` | 61 |
 | `docs/product-quality/community-profile-quality-report.md` | `true` | `08b95453f468cd80749bb3d6195c71a5630f39278ae4a76d49a0c1e2373d5ef0` | 64 |
 | `docs/product-quality/competitive-scorecard.md` | `true` | `db68e5bcc24f30ad3e0adb9c98e7ea3afcec47aa50392e3a0658a4a504330d60` | 67 |
-| `docs/product-quality/dead-export-candidates-report.md` | `true` | `dc08c5f4efa61cfb0e8b56df2ec102785dda21630d6efd8c34e814179ac83d4b` | 112 |
+| `docs/product-quality/dead-export-candidates-report.md` | `true` | `25d160540f8856538f10c6607483498579c6bfcff49639e192a231970bc9ec36` | 112 |
 | `docs/product-quality/dependency-governance-quality-report.md` | `true` | `4edaa9099276c14919ae5390999a4a356727137f106b62ee84a0db4e8b4aa12a` | 179 |
 | `docs/product-quality/dependency-topology-report.md` | `true` | `92acb7cfc97c2a9559ca140071d7fb4839319335b86be304c206d3c7f9e99dbf` | 117 |
 | `docs/product-quality/doc-link-integrity-report.md` | `true` | `16378b14406beb31065bc8a2c7af9971b8d88f444992c9da1ae6973ec43189fd` | 124 |
@@ -361,7 +361,7 @@ This map binds public Metaforge symbols to local evidence, allowed claims, expli
 | `docs/product-quality/release-artifact-reproducibility-report.md` | `true` | `fcf65b88d294218421bce03071538ce5d927f9b5494ce3f26855683fda39182f` | 57 |
 | `docs/product-quality/research-brief-validation-report.md` | `true` | `2d2b174682b62e550d6629f1b202a83a19d928ac3f1b374a432cbb699f9ecc9f` | 75 |
 | `docs/product-quality/runtime-doctor-regression-fixtures.md` | `true` | `7b9ef7fba04ffc74b6de423ebc5dff32a1dda99893bb6f8b4a57ea77e7c0cb33` | 62 |
-| `docs/product-quality/script-duplication-audit-report.md` | `true` | `939333855e57512209bd7ba58d4c9f724feb3bd277eb1ac6ffcdd26c211bfa30` | 97 |
+| `docs/product-quality/script-duplication-audit-report.md` | `true` | `0baf5d2390b4348147afb5080b4dfd78ea50b7007a6cde7fdef1e4e2d5d1d1e0` | 97 |
 | `docs/product-quality/source-controlled-checks-report.md` | `true` | `7084a4cc99bef3c3db10e92eac758049f7fbc969c78ed4d2ee7a8652b8d1c5d5` | 51 |
 | `docs/product-quality/source-license-metadata-quality-report.md` | `true` | `e271bdd028ae0317bc2bf53d4dff6f7294c383a3b96e5c2326e1124a16422c10` | 184 |
 | `docs/product-quality/terminal-bench-readiness-report.md` | `true` | `c76ebab4c267c229af18a7c6708eb0a56768823ec6d5c0edc9f7b2368466e7bc` | 69 |

--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -59,7 +59,7 @@ describe('public artifact hygiene scanner', () => {
     mkdirSync(planningDir, { recursive: true })
     writeFileSync(
       join(planningDir, 'PROJECT.md'),
-      'Always call GPT 5.5 + Opus 4.7; fallback must not use gpt-4o.\n',
+      'Always call GPT 5.5 + configured Claude Opus; fallback must not use gpt-4o.\n',
     )
 
     const result = runHygiene(repo)

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -880,7 +880,7 @@ export async function runHeadless(
     // v0.2 Orchestra system messages — always surfaced to stderr so users
     // see them regardless of --output-format / --verbose. The orchestra
     // tags ([Phase 2 Skeptic], [Phase 3 Cross-Review], [Phase 4 Human
-    // Gate], [Opus 4.7 야당]) are how we identify our own payloads vs
+    // Gate], [Opus 야당]) are how we identify our own payloads vs
     // unrelated informational messages.
     if (
       message.type === 'system' &&
@@ -892,7 +892,7 @@ export async function runHeadless(
           content.includes('[Phase 2') ||
           content.includes('[Phase 3') ||
           content.includes('[Phase 4') ||
-          content.includes('[Opus 4.7')
+          content.includes('[Opus 야당')
         if (isOrchestra) {
           try {
             process.stderr.write(`${content}\n`)

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -115,8 +115,7 @@ export const CLAUDE_CODE_DOCS_MAP_URL =
 export const SYSTEM_PROMPT_DYNAMIC_BOUNDARY =
   '__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__'
 
-// @[MODEL LAUNCH]: Update the latest frontier model.
-const FRONTIER_MODEL_NAME = 'Claude Opus 4.7'
+const FAST_MODE_MODEL_DESCRIPTION = 'configured Claude model route'
 
 // @[MODEL LAUNCH]: Update the model family IDs below to the latest in each tier.
 const CLAUDE_4_5_OR_4_6_MODEL_IDS = {
@@ -694,13 +693,13 @@ export async function computeSimpleEnvInfo(
     knowledgeCutoffMessage,
     process.env.USER_TYPE === 'ant' && isUndercover()
       ? null
-      : `The most recent Claude model family is Claude 4.5/4.6/4.7. Model IDs — Opus 4.7: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.opus}', Sonnet 4.6: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.sonnet}', Haiku 4.5: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.haiku}'. When building AI applications, default to the latest and most capable Claude models.`,
+      : `Claude model examples in this checkout are configuration hints, not a current-model guarantee. Example configured IDs — Opus route: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.opus}', Sonnet route: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.sonnet}', Haiku route: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.haiku}'. For new AI applications, verify current model availability in the provider's official documentation before making recency or capability claims.`,
     process.env.USER_TYPE === 'ant' && isUndercover()
       ? null
       : `OpenClaude is available as a CLI in the terminal and can be used across local development environments and IDE workflows.`,
     process.env.USER_TYPE === 'ant' && isUndercover()
       ? null
-      : `Fast mode for OpenClaude uses the same ${FRONTIER_MODEL_NAME} model with faster output. It does NOT switch to a different model. It can be toggled with /fast.`,
+      : `Fast mode for OpenClaude uses the same ${FAST_MODE_MODEL_DESCRIPTION} with faster output. It does NOT switch to a different model. It can be toggled with /fast.`,
   ].filter(item => item !== null)
 
   return [

--- a/src/query/orchestra.test.ts
+++ b/src/query/orchestra.test.ts
@@ -149,7 +149,7 @@ describe('query orchestra integration', () => {
       uuid: () => 'query-chain-id',
       orchestraGuidance: async () => ({
         blockingError:
-          'Claude Opus 4.7 planner failed before GPT implementation could start.',
+          'Claude Opus (configured) planner failed before GPT implementation could start.',
       }),
       orchestraImplementerRoute: () => ({
         route: {
@@ -179,7 +179,9 @@ describe('query orchestra integration', () => {
     expect(modelCalls.length).toBe(0)
     expect(
       yielded.some((m: any) =>
-        JSON.stringify(m.message?.content ?? '').includes('Claude Opus 4.7'),
+        JSON.stringify(m.message?.content ?? '').includes(
+          'Claude Opus (configured)',
+        ),
       ),
     ).toBe(true)
   })

--- a/src/query/skeptic.test.ts
+++ b/src/query/skeptic.test.ts
@@ -58,7 +58,7 @@ const baseDeps = {
 describe('query orchestra skeptic integration', () => {
   test('fires the skeptic exactly once per turn after a tool_use-free assistant message', async () => {
     const skepticCalls: any[] = []
-    const skepticMessage = createSystemMessage('[Opus 4.7 야당] dissent', 'warning')
+    const skepticMessage = createSystemMessage('[Opus 야당] dissent', 'warning')
 
     const deps = {
       ...baseDeps,

--- a/src/services/orchestra/config.test.ts
+++ b/src/services/orchestra/config.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   CODEX_GPT_55_ALIAS,
-  CLAUDE_OPUS_47_ALIAS,
+  CLAUDE_OPUS_ALIAS,
   DEFAULT_ORCHESTRA_SETTINGS,
   resolveOrchestraSettings,
 } from './config.js'
@@ -21,7 +21,7 @@ describe('orchestra config', () => {
     expect(settings.workerPolicy).toBe('codex-first')
     expect(settings.verifierPolicy).toBe('codex-default-opus-on-risk')
     expect(settings.parallelism).toBe('independent-lanes-only')
-    expect(settings.roles.planner).toBe(CLAUDE_OPUS_47_ALIAS)
+    expect(settings.roles.planner).toBe(CLAUDE_OPUS_ALIAS)
     expect(settings.roles.implementer).toBe(CODEX_GPT_55_ALIAS)
   })
 
@@ -63,7 +63,7 @@ describe('orchestra config', () => {
   })
 
   test('v0.2-locked mode forces enabled=true, plannerPolicy=always, everyTurn=true regardless of user overrides', () => {
-    // The lock guarantees the v0.2 contract: GPT 5.5 + Opus 4.7 ALWAYS run
+    // The lock guarantees the v0.2 contract: GPT 5.5 + Claude Opus ALWAYS run
     // together on every turn. Even if a user accidentally writes
     // `enabled: false` or `plannerPolicy: 'off'` in settings.json, the lock
     // wins. This protects the v0.2 invariant from accidental footguns.

--- a/src/services/orchestra/config.ts
+++ b/src/services/orchestra/config.ts
@@ -1,7 +1,7 @@
 import type { SettingsJson } from '../../utils/settings/types.js'
 
 export const CODEX_GPT_55_ALIAS = 'Codex GPT 5.5'
-export const CLAUDE_OPUS_47_ALIAS = 'Claude Opus 4.7'
+export const CLAUDE_OPUS_ALIAS = 'Claude Opus (configured)'
 
 export type OrchestraLead = 'codex'
 export type OrchestraVisibility = 'codex-final'
@@ -14,7 +14,7 @@ export type OrchestraMode =
    * v0.2 always-on opposition mode. The lock forces enabled=true,
    * plannerPolicy='always', and everyTurn=true regardless of any user
    * settings.json overrides. Used by users who have explicitly opted into
-   * the GPT 5.5-king + Opus 4.7-opposition vision and don't want a
+   * the GPT 5.5-king + Claude Opus opposition vision and don't want a
    * footgun setting (e.g. an accidental `enabled: false`) to silently
    * collapse the orchestra back into single-model behaviour.
    */
@@ -41,7 +41,7 @@ export type ResolvedOrchestraSettings = {
   /**
    * When true, the orchestra runs on EVERY user turn instead of only the
    * first. Pairs with the v0.2 "always-on opposition" vision: GPT 5.5 as
-   * the king + Opus 4.7 as the constant opposition party. Default false
+   * the king + Claude Opus as the constant opposition party. Default false
    * for backward compatibility — token-conservative users keep the legacy
    * turn-1-only behaviour.
    */
@@ -97,7 +97,7 @@ export const DEFAULT_ORCHESTRA_SETTINGS: ResolvedOrchestraSettings = {
   shadowEnabled: false,
   shadowEveryTurn: false,
   roles: {
-    planner: CLAUDE_OPUS_47_ALIAS,
+    planner: CLAUDE_OPUS_ALIAS,
     implementer: CODEX_GPT_55_ALIAS,
   },
   models: {},

--- a/src/services/orchestra/experimentMetrics.ts
+++ b/src/services/orchestra/experimentMetrics.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 5 Validation Experiment metrics.
  *
- * Goal: quantify whether Opus 4.7 is "differently wrong than GPT 5.5" enough
+ * Goal: quantify whether the configured Claude Opus route is "differently wrong than GPT 5.5" enough
  * to justify keeping it in the orchestra. v0.3 will use these numbers to
  * decide keep / demote / remove.
  *

--- a/src/services/orchestra/modelAliases.test.ts
+++ b/src/services/orchestra/modelAliases.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   CODEX_GPT_55_ALIAS,
-  CLAUDE_OPUS_47_ALIAS,
+  CLAUDE_OPUS_ALIAS,
   resolveOrchestraModelAlias,
 } from './modelAliases.js'
 
@@ -17,7 +17,7 @@ describe('orchestra model alias resolver', () => {
       env: { OPENCLAUDE_ORCHESTRA_PLANNER_MODEL: 'claude-opus-env' },
     })
 
-    expect(result.displayAlias).toBe(CLAUDE_OPUS_47_ALIAS)
+    expect(result.displayAlias).toBe(CLAUDE_OPUS_ALIAS)
     expect(result.model).toBe('claude-opus-explicit')
     expect(result.source).toBe('settings')
     expect(result.diagnostic).toBeUndefined()
@@ -46,10 +46,10 @@ describe('orchestra model alias resolver', () => {
       apiProvider: 'codex',
     })
 
-    expect(planner.displayAlias).toBe(CLAUDE_OPUS_47_ALIAS)
+    expect(planner.displayAlias).toBe(CLAUDE_OPUS_ALIAS)
     expect(planner.model).toBe('claude-opus-4-7')
     expect(planner.source).toBe('fallback')
-    expect(planner.diagnostic).toContain(CLAUDE_OPUS_47_ALIAS)
+    expect(planner.diagnostic).toContain(CLAUDE_OPUS_ALIAS)
 
     expect(implementer.displayAlias).toBe(CODEX_GPT_55_ALIAS)
     expect(implementer.model).toBe('gpt-5.5')

--- a/src/services/orchestra/modelAliases.ts
+++ b/src/services/orchestra/modelAliases.ts
@@ -3,11 +3,11 @@ import { getAPIProvider, type APIProvider } from '../../utils/model/providers.js
 import type { SettingsJson } from '../../utils/settings/types.js'
 import {
   CODEX_GPT_55_ALIAS,
-  CLAUDE_OPUS_47_ALIAS,
+  CLAUDE_OPUS_ALIAS,
   resolveOrchestraSettings,
 } from './config.js'
 
-export { CODEX_GPT_55_ALIAS, CLAUDE_OPUS_47_ALIAS }
+export { CODEX_GPT_55_ALIAS, CLAUDE_OPUS_ALIAS }
 
 export type OrchestraRole = 'planner' | 'implementer'
 
@@ -69,9 +69,7 @@ export function resolveOrchestraModelAlias(
   const apiProvider = options.apiProvider ?? getAPIProvider()
   const orchestra = resolveOrchestraSettings(options.settings)
   const displayAlias =
-    role === 'planner'
-      ? CLAUDE_OPUS_47_ALIAS
-      : CODEX_GPT_55_ALIAS
+    role === 'planner' ? CLAUDE_OPUS_ALIAS : CODEX_GPT_55_ALIAS
   const explicitSetting = trim(orchestra.models[role])
   if (explicitSetting) {
     return {

--- a/src/services/orchestra/orchestrator.test.ts
+++ b/src/services/orchestra/orchestrator.test.ts
@@ -44,7 +44,7 @@ describe('orchestra advisory orchestration', () => {
     ).toBeNull()
   })
 
-  test('builds hidden Opus 4.7 planner requests with max effort', () => {
+  test('builds hidden Claude Opus planner requests with max effort', () => {
     const request = buildClaudeLoginPlannerRequest({
       model: 'claude-opus-4-7',
       prompt: 'Plan the next step.',
@@ -110,7 +110,7 @@ describe('orchestra advisory orchestration', () => {
   })
 
   test('everyTurn config opens orchestra to every user turn (v0.2 always-on mode)', () => {
-    // v0.2 vision: GPT 5.5 + Opus 4.7 must run together on EVERY turn, not just
+    // v0.2 vision: GPT 5.5 + Claude Opus must run together on EVERY turn, not just
     // turn 1. The everyTurn config knob enables this without a hard breaking
     // change — default stays false, but v0.2-locked mode flips it on.
     expect(
@@ -277,7 +277,9 @@ describe('orchestra advisory orchestration', () => {
 
     expect(result.metaMessage).toBeUndefined()
     expect(result.diagnostic).toContain('rate limited')
-    expect(result.blockingError).toContain('Claude Opus 4.7 planner failed')
+    expect(result.blockingError).toContain(
+      'Claude Opus (configured) planner failed',
+    )
     expect(result.blockingError).toContain('rate limited')
     expect(events).toEqual([
       expect.objectContaining({
@@ -317,7 +319,9 @@ describe('orchestra advisory orchestration', () => {
 
     expect(result.metaMessage).toBeUndefined()
     expect(result.blockingError).toBeUndefined()
-    expect(result.noticeMessage).toContain('Claude Opus 4.7 planner failed')
+    expect(result.noticeMessage).toContain(
+      'Claude Opus (configured) planner failed',
+    )
   })
 
   test('blocks orchestra recursion from skeptic self-call', () => {

--- a/src/services/orchestra/orchestrator.ts
+++ b/src/services/orchestra/orchestrator.ts
@@ -17,7 +17,7 @@ import { OAUTH_BETA_HEADER } from '../../constants/oauth.js'
 import { sideQuery } from '../../utils/sideQuery.js'
 import type { ToolUseContext } from '../../Tool.js'
 import {
-  CLAUDE_OPUS_47_ALIAS,
+  CLAUDE_OPUS_ALIAS,
   resolveOrchestraSettings,
   type OrchestraPlannerFailurePolicy,
   type OrchestraPlannerPolicy,
@@ -412,7 +412,7 @@ function formatList(title: string, items: string[]): string {
 
 export function formatOrchestraMeta(advisory: OrchestraAdvisory): string {
   return [
-    '<orchestra-advisory source="Claude Opus 4.7" visibility="hidden">',
+    '<orchestra-advisory source="Claude Opus (configured)" visibility="hidden">',
     'Use this as private planning guidance. Codex remains the only execution and write authority.',
     '',
     `Goal: ${advisory.goal}`,
@@ -489,7 +489,7 @@ function formatPlannerFailureMessage(params: {
   message: string
 }): string {
   return (
-    `${CLAUDE_OPUS_47_ALIAS} planner failed before implementation guidance was available ` +
+    `${CLAUDE_OPUS_ALIAS} planner failed before implementation guidance was available ` +
     `(${params.model}, ${params.kind}): ${params.message}`
   )
 }
@@ -701,7 +701,7 @@ export async function buildSkepticDissent({
   if (!hasCritiqueWorthyAssistantText(params.messages)) {
     return {}
   }
-  // Skeptic uses the same Opus 4.7 OAuth path as the planner — same model
+  // Skeptic uses the same configured Claude Opus path as the planner — same model
   // resolution alias keeps env / settings overrides consistent across roles.
   const skepticResolution = resolveOrchestraModelAlias('planner', {
     settings: params.settings,

--- a/src/services/orchestra/shadowExecutor.ts
+++ b/src/services/orchestra/shadowExecutor.ts
@@ -2,7 +2,7 @@ import { SHADOW_LABELS, type ShadowLabel, type ShadowWorktree } from './worktree
 
 /**
  * Phase 3 Shadow Executor — orchestrates 3 candidate patches in isolated
- * worktrees: GPT-A primary alternative, GPT-B alternative-approach, Opus 4.7
+ * worktrees: GPT-A primary alternative, GPT-B alternative-approach, Claude Opus
  * shadow. Each worker is responsible for actually mutating its own worktree
  * (commits + diff capture) and returning a ShadowCandidate summary.
  *
@@ -139,6 +139,6 @@ export function shadowSystemPromptFor(label: ShadowLabel): string {
     case 'gpt-b':
       return 'You are GPT-B. The other GPT instance is solving this same task with its primary approach. You MUST take a deliberately different approach — different data structure, different algorithm, different abstraction boundary. If your first instinct matches GPT-A, pick the second-best alternative.'
     case 'opus-shadow':
-      return 'You are Claude Opus 4.7 acting as the shadow executor (야당 그림자 구현). The visible lead is GPT 5.5. Produce your own implementation independently, paying special attention to risks and edge cases the GPT path may underweight.'
+      return 'You are Claude Opus acting as the configured shadow executor (야당 그림자 구현). The visible lead is GPT 5.5. Produce your own implementation independently, paying special attention to risks and edge cases the GPT path may underweight.'
   }
 }

--- a/src/services/orchestra/shadowReview.ts
+++ b/src/services/orchestra/shadowReview.ts
@@ -355,7 +355,7 @@ async function opusShadowWorker(
       model: 'claude-opus-4-7',
       max_tokens: 4096,
       system:
-        'You are Claude Opus 4.7 acting as a shadow patch generator (야당 그림자). Output JSON only.',
+        'You are Claude Opus acting as the configured shadow patch generator (야당 그림자). Output JSON only.',
       messages: [{ role: 'user', content: workerPrompt(input, 'opus-shadow') }],
       querySource: 'orchestra_shadow_worker' as never,
       maxRetries: 0,
@@ -477,7 +477,7 @@ const opusReviewer: ReviewerFn = async ({ candidate, signal }) => {
     model: 'claude-opus-4-7',
     max_tokens: 1024,
     system:
-      'You are Claude Opus 4.7 reviewing a candidate patch as the opposition (야당). Output JSON only.',
+      'You are Claude Opus reviewing a candidate patch as the configured opposition (야당). Output JSON only.',
     messages: [{ role: 'user', content: reviewerPrompt(candidate) }],
     querySource: 'orchestra_cross_reviewer_opus' as never,
     maxRetries: 0,

--- a/src/services/orchestra/skeptic.test.ts
+++ b/src/services/orchestra/skeptic.test.ts
@@ -164,7 +164,7 @@ describe('orchestra skeptic — formatDissent display', () => {
       severity: 'caution',
     }
     const text = formatDissent(report)
-    expect(text).toContain('[Opus 4.7 야당]')
+    expect(text).toContain('[Opus 야당]')
     expect(text).toContain('테스트 누락')
     expect(text).toContain('오류 처리 없음')
     expect(text).toContain('idempotent 가정')
@@ -174,7 +174,7 @@ describe('orchestra skeptic — formatDissent display', () => {
 
   test('compresses fully empty dissent into a single advisory line', () => {
     const text = formatDissent(EMPTY_DISSENT)
-    expect(text).toContain('[Opus 4.7 야당]')
+    expect(text).toContain('[Opus 야당]')
     expect(text.split('\n').length).toBeLessThanOrEqual(2)
   })
 })

--- a/src/services/orchestra/skeptic.ts
+++ b/src/services/orchestra/skeptic.ts
@@ -178,7 +178,7 @@ export function buildSkepticPrompt(params: SkepticPromptParams): string {
       ]
     : []
   return [
-    'You are Claude Opus 4.7 acting as the opposition party (야당) in an orchestra.',
+    'You are Claude Opus acting as the configured opposition party (야당) in an orchestra.',
     'The visible lead Codex/GPT 5.5 has just produced a response. Your role is read-only critique.',
     'You have NO tool access and MUST NOT propose code edits — only highlight risks,',
     'questioned assumptions, and scope drift. Output JSON ONLY in Korean.',
@@ -318,7 +318,7 @@ export function dissentSeverityToMessageLevel(
   }
 }
 
-const SKEPTIC_HEADER = '[Opus 4.7 야당]'
+const SKEPTIC_HEADER = '[Opus 야당]'
 const EMPTY_HEADLINE_FALLBACK = '유의미한 이견 없음'
 
 function isReportEmpty(report: DissentReport): boolean {

--- a/src/services/orchestra/usageLog.ts
+++ b/src/services/orchestra/usageLog.ts
@@ -6,7 +6,7 @@ import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
 
 export type OrchestraUsageEvent = {
   timestamp?: string
-  // v0.2 added 'skeptic' — Opus 4.7 야당 post-implementation dissent role.
+  // v0.2 added 'skeptic' — configured Claude Opus 야당 post-implementation dissent role.
   // It runs read-only on turn end (after the GPT response yields) and is
   // logged with the same status transitions as planner/implementer.
   //

--- a/src/services/orchestra/worktreeManager.ts
+++ b/src/services/orchestra/worktreeManager.ts
@@ -6,7 +6,7 @@ import { execFileNoThrowWithCwd } from '../../utils/execFileNoThrow.js'
  * Phase 3 Shadow Executor — git worktree life-cycle.
  *
  * Three shadow worktrees per task: GPT-A primary alternative, GPT-B alternative
- * approach, Opus 4.7 shadow. Each lives under `{gitRoot}/.openclaude-shadows/
+ * approach, Claude Opus shadow. Each lives under `{gitRoot}/.openclaude-shadows/
  * {taskId}/{label}` on a dedicated branch `openclaude-shadow/{taskId}/{label}`,
  * so the user's main worktree is never touched (D3=i: Phase 3 is read-only
  * compared, Phase 4 will decide promotion).

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -67,13 +67,13 @@ export function getAttributionTexts(): AttributionTexts {
 
   // @[MODEL LAUNCH]: Update the hardcoded fallback model name below (guards against codename leaks).
   // For internal repos, use the real model name. For external repos,
-  // fall back to "Claude Opus 4.7" for unrecognized models to avoid leaking codenames.
+  // fall back to a generic public family name for unrecognized models.
   const model = getMainLoopModel()
   const isKnownPublicModel = getPublicModelDisplayName(model) !== null
   const modelName =
     isInternalModelRepoCached() || isKnownPublicModel
       ? getPublicModelName(model)
-      : 'Claude Opus 4.7'
+      : 'Claude Opus'
   const defaultAttribution =
     '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
   const coAuthorDomain =

--- a/src/utils/model/agent.ts
+++ b/src/utils/model/agent.ts
@@ -141,7 +141,7 @@ export function getAgentModelOptions(): AgentModelOption[] {
     {
       value: 'opus',
       label: 'Opus',
-      description: 'Most capable for complex reasoning tasks',
+      description: 'Configured for complex reasoning tasks',
     },
     {
       value: 'haiku',

--- a/src/utils/model/configs.ts
+++ b/src/utils/model/configs.ts
@@ -20,7 +20,7 @@ export const OPENAI_MODEL_DEFAULTS = {
 // Override with GEMINI_MODEL env var.
 // ---------------------------------------------------------------------------
 export const GEMINI_MODEL_DEFAULTS = {
-  opus: 'gemini-2.5-pro',   // most capable
+  opus: 'gemini-2.5-pro',   // strong reasoning
   sonnet: 'gemini-2.0-flash',              // balanced
   haiku: 'gemini-2.0-flash-lite',          // fast & cheap
 } as const

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -423,9 +423,9 @@ export function getClaudeAiUserDefaultModelDescription(
 ): string {
   if (isMaxSubscriber() || isTeamPremiumSubscriber()) {
     if (isOpus1mMergeEnabled()) {
-      return `Opus 4.7 with 1M context · Most capable for complex work${fastMode ? getOpus46PricingSuffix(true) : ''}`
+      return `Opus 4.7 with 1M context · Configured for complex work${fastMode ? getOpus46PricingSuffix(true) : ''}`
     }
-    return `Opus 4.7 · Most capable for complex work${fastMode ? getOpus46PricingSuffix(true) : ''}`
+    return `Opus 4.7 · Configured for complex work${fastMode ? getOpus46PricingSuffix(true) : ''}`
   }
   return 'Sonnet 4.6 · Best for everyday tasks'
 }
@@ -434,7 +434,7 @@ export function renderDefaultModelSetting(
   setting: ModelName | ModelAlias,
 ): string {
   if (setting === 'opusplan') {
-    return 'Opus 4.7 in plan mode, else Sonnet 4.6'
+    return 'Configured Opus in plan mode, else Sonnet 4.6'
   }
   return renderModelName(parseUserSpecifiedModel(setting))
 }

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -165,8 +165,8 @@ function getOpus46Option(fastMode = false): ModelOption {
   return {
     value: is3P ? getModelStrings().opus46 : 'opus',
     label: 'Opus',
-    description: `${opusName} · Most capable for complex work${getOpus46PricingSuffix(fastMode)}`,
-    descriptionForModel: `${opusName} - most capable for complex work`,
+    description: `${opusName} · Configured for complex work${getOpus46PricingSuffix(fastMode)}`,
+    descriptionForModel: `${opusName} - configured for complex work`,
   }
 }
 
@@ -243,7 +243,7 @@ function getMaxOpusOption(fastMode = false): ModelOption {
   return {
     value: 'opus',
     label: 'Opus',
-    description: `Opus 4.7 · Most capable for complex work${fastMode ? getOpus46PricingSuffix(true) : ''}`,
+    description: `Opus 4.7 · Configured for complex work${fastMode ? getOpus46PricingSuffix(true) : ''}`,
   }
 }
 
@@ -272,9 +272,9 @@ function getMergedOpus1MOption(fastMode = false): ModelOption {
   return {
     value: is3P ? getModelStrings().opus46 + '[1m]' : 'opus[1m]',
     label: 'Opus (1M context)',
-    description: `${opusName} with 1M context · Most capable for complex work${!is3P && fastMode ? getOpus46PricingSuffix(fastMode) : ''}`,
+    description: `${opusName} with 1M context · Configured for complex work${!is3P && fastMode ? getOpus46PricingSuffix(fastMode) : ''}`,
     descriptionForModel:
-      `${opusName} with 1M context - most capable for complex work`,
+      `${opusName} with 1M context - configured for complex work`,
   }
 }
 
@@ -294,7 +294,7 @@ function getOpusPlanOption(): ModelOption {
   return {
     value: 'opusplan',
     label: 'Opus Plan Mode',
-    description: 'Use Opus 4.7 in plan mode, Sonnet 4.6 otherwise',
+    description: 'Use configured Opus in plan mode, Sonnet 4.6 otherwise',
   }
 }
 

--- a/src/utils/providerAutoDetect.ts
+++ b/src/utils/providerAutoDetect.ts
@@ -9,7 +9,7 @@
  * picker flow should take over.
  *
  * Detection priority (first match wins):
- *   1. ANTHROPIC_API_KEY → first-party Claude (most capable default)
+ *   1. ANTHROPIC_API_KEY → first-party Claude default
  *   2. Codex: CODEX_API_KEY, CHATGPT_ACCOUNT_ID, or valid ~/.codex/auth.json
  *   3. GitHub Copilot: GITHUB_TOKEN or GH_TOKEN
  *   4. OPENAI_API_KEY / OPENAI_API_KEYS

--- a/src/utils/settings/orchestra.test.ts
+++ b/src/utils/settings/orchestra.test.ts
@@ -16,7 +16,7 @@ describe('SettingsSchema orchestra', () => {
         verifierPolicy: 'codex-default-opus-on-risk',
         parallelism: 'independent-lanes-only',
         roles: {
-          planner: 'Claude Opus 4.7',
+          planner: 'Claude Opus (configured)',
           implementer: 'Codex GPT 5.5',
         },
         models: {

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -748,7 +748,7 @@ export const SettingsSchema = lazySchema(() =>
             .enum(['balanced', 'codex-dominant', 'codex-max', 'v0.2-locked'])
             .optional()
             .describe(
-              'High-level orchestration posture. codex-dominant keeps Codex as the default executor and uses Opus only on risk-gated turns. v0.2-locked forces always-on dual-model orchestra (GPT 5.5 + Opus 4.7 every turn) and overrides any conflicting enabled/plannerPolicy/everyTurn user settings.',
+              'High-level orchestration posture. codex-dominant keeps Codex as the default executor and uses Opus only on risk-gated turns. v0.2-locked forces always-on dual-model orchestra (GPT 5.5 + configured Claude Opus every turn) and overrides any conflicting enabled/plannerPolicy/everyTurn user settings.',
             ),
           plannerPolicy: z
             .enum(['always', 'risk-gated', 'off'])
@@ -805,7 +805,7 @@ export const SettingsSchema = lazySchema(() =>
             })
             .optional()
             .describe(
-              'Display aliases for orchestration roles, e.g. Claude Opus 4.7 and Codex GPT 5.5.',
+              'Display aliases for orchestration roles, e.g. Claude Opus (configured) and Codex GPT 5.5.',
             ),
           models: z
             .object({

--- a/src/utils/swarm/teammateModel.ts
+++ b/src/utils/swarm/teammateModel.ts
@@ -3,7 +3,7 @@ import { getAPIProvider } from '../model/providers.js'
 
 // @[MODEL LAUNCH]: Update the fallback model below.
 // When the user has never set teammateDefaultModel in /config, new teammates
-// use Opus 4.7. Must be provider-aware so Bedrock/Vertex/Foundry customers get
+// use the configured Opus fallback. Must be provider-aware so Bedrock/Vertex/Foundry customers get
 // the correct model ID.
 export function getHardcodedTeammateModelFallback(): string {
   return CLAUDE_OPUS_4_7_CONFIG[getAPIProvider()]


### PR DESCRIPTION
## Summary
- Replace Orchestra-facing `Claude Opus 4.7` display aliases with configured Claude Opus route wording.
- Remove `latest/most capable` Claude recency and superiority wording from system prompt/model UI surfaces while preserving existing runtime model IDs.
- Refresh the public claim-boundary report so the Metaforge thesis remains Meta + MFH + Orchestra OS, with OpenClaude as runtime substrate.

## Verification
- `bun test src/services/orchestra/config.test.ts src/services/orchestra/modelAliases.test.ts src/services/orchestra/orchestrator.test.ts src/services/orchestra/skeptic.test.ts src/query/orchestra.test.ts src/query/skeptic.test.ts src/utils/settings/orchestra.test.ts scripts/public-artifact-hygiene.test.ts src/utils/model/model.opus47.test.ts`
- `bun run typecheck --pretty false`
- `bun run build`
- `bun run product:public-claim-boundary`
- `bun run product:public-claim-boundary:check`
- `bun run verify:privacy`
- `git diff --check`

## Boundary
- `bun run product:quality` was executed end-to-end locally and reached the existing protected environment boundary `PRODUCT_QUALITY_GATE_BLOCKED_BY_LOCAL_VSCODE_CLI_UNAVAILABLE`; this is not a product/readiness claim.