### PR TITLE
[codex] Report all public hygiene leak labels

### DIFF
--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -178,6 +178,28 @@ describe('public artifact hygiene scanner', () => {
     expect(`${result.stdout}\n${result.stderr}`).toContain('README.md')
   })
 
+  test('reports exact pasted AGENTS local-context headers alongside generic path findings', () => {
+    const repo = makeTempRepo()
+    writeFileSync(
+      join(repo, 'AGENTS.md'),
+      [
+        `# AGENTS.md instructions for ${windowsPrivatePath}`,
+        '<environment_context>',
+        '<workspace_roots>',
+      ].join('\n'),
+    )
+
+    const result = runHygiene(repo)
+    const output = `${result.stdout}\n${result.stderr}`
+
+    expect(result.status).not.toBe(0)
+    expect(output).toContain('AGENTS.md')
+    expect(output).toContain('windows-user-path')
+    expect(output).toContain('pasted-agents-local-context')
+    expect(output).toContain('environment-context')
+    expect(output).toContain('workspace-roots-context')
+  })
+
   test('rejects raw public-comment UI dumps in public docs', () => {
     const repo = makeTempRepo()
     writeFileSync(

--- a/scripts/public-artifact-hygiene.ts
+++ b/scripts/public-artifact-hygiene.ts
@@ -327,7 +327,6 @@ for (const file of files) {
     }
     if (pattern.test(inspect)) {
       findings.push(`${relativePath}: ${label}`)
-      break
     }
   }
 }


### PR DESCRIPTION
## Summary
- report every matching public-hygiene leak label for a file instead of stopping after the first label
- add an exact regression fixture for the leaked AGENTS/local Windows context header shape

## Why
Community feedback called out local folder exposure in public AGENTS-style material. The scanner already blocked the file, but the generic Windows-path label could hide the more actionable pasted-context labels. This makes the failure report useful enough to fix the real source of trust damage.

## Validation
- RED: `bun test scripts/public-artifact-hygiene.test.ts` failed because only `windows-user-path` was reported
- GREEN: `bun test scripts/public-artifact-hygiene.test.ts` -> 31 pass, 0 fail
- `bun run product:public-artifact-hygiene` -> PASS, 641 files scanned
- `bun test scripts/public-repo-readiness.test.ts scripts/product-github-remote-surface-audit.test.ts` -> 39 pass, 0 fail
- `bun run verify:privacy` -> PASS
- `bun run typecheck --pretty false` -> PASS
- `git diff --check` -> PASS

## Claim Boundary
This improves configured public artifact hygiene diagnostics only. It does not claim full-history secret cleanliness, GitHub secret-scanning alert status, release readiness, production readiness, or external validation.