### PR TITLE
Harden ZIP cache and report path hygiene

### DIFF
--- a/scripts/product-report-sanitizer.test.ts
+++ b/scripts/product-report-sanitizer.test.ts
@@ -9,7 +9,7 @@ describe('product report public sanitizer', () => {
   const worktreeRepoPath = [
     winHome,
     desktop,
-    '내 순수 재미',
+    '한글 테스트 경로',
     'openclaude-worktrees',
     'public-feedback-static-proof',
   ].join('\\')
@@ -44,7 +44,7 @@ describe('product report public sanitizer', () => {
     expect(scrubbed).toContain('<repo>\\dist\\cli.mjs --version')
     expect(scrubbed).toContain('"cwd":"<repo>"')
     expect(scrubbed).not.toContain('<user-home>')
-    expect(scrubbed).not.toContain('내 순수 재미')
+    expect(scrubbed).not.toContain('한글 테스트 경로')
     expect(scrubbed).not.toContain(winUserPrefix)
   })
 

--- a/scripts/product-report-sanitizer.test.ts
+++ b/scripts/product-report-sanitizer.test.ts
@@ -6,6 +6,13 @@ describe('product report public sanitizer', () => {
   const desktop = 'Desk' + 'top'
   const repoPath = [winHome, desktop, 'project space', 'openclaude-0.6.0'].join('\\')
   const posixRepoPath = ['C:', 'Users', 'alice', desktop, 'project-space', 'openclaude-0.6.0'].join('/')
+  const worktreeRepoPath = [
+    winHome,
+    desktop,
+    '내 순수 재미',
+    'openclaude-worktrees',
+    'public-feedback-static-proof',
+  ].join('\\')
   const bunExePath = [winHome, 'AppData', 'Roaming', 'npm', 'node_modules', 'bun', 'bin', 'bun.exe'].join('\\')
   const winUserPrefix = ['C:', 'Users'].join('\\')
   const posixUserPrefix = ['C:', 'Users'].join('/')
@@ -24,6 +31,21 @@ describe('product report public sanitizer', () => {
     expect(scrubbed).toContain('<bun>')
     expect(scrubbed).not.toContain(winUserPrefix)
     expect(scrubbed).not.toContain(posixUserPrefix)
+  })
+
+  test('scrubs the current repo root before broader user-home placeholders', () => {
+    const text = [
+      `${worktreeRepoPath}\\dist\\cli.mjs --version`,
+      `"cwd":"${worktreeRepoPath.replaceAll('\\', '\\\\')}"`,
+    ].join('\n')
+
+    const scrubbed = scrubPublicArtifactText(text, { repoRoot: worktreeRepoPath })
+
+    expect(scrubbed).toContain('<repo>\\dist\\cli.mjs --version')
+    expect(scrubbed).toContain('"cwd":"<repo>"')
+    expect(scrubbed).not.toContain('<user-home>')
+    expect(scrubbed).not.toContain('내 순수 재미')
+    expect(scrubbed).not.toContain(winUserPrefix)
   })
 
   test('recursively scrubs public report values', () => {

--- a/scripts/product-report-sanitizer.ts
+++ b/scripts/product-report-sanitizer.ts
@@ -2,7 +2,35 @@ const sep = String.raw`(?:\\+|/)`
 const segment = String.raw`[^\\/"]+`
 const userSegment = String.raw`[^\\/"]+`
 
-const replacements: Array<{ pattern: RegExp; replacement: string }> = [
+type ScrubOptions = {
+  repoRoot?: string
+}
+
+type Replacement = {
+  pattern: RegExp
+  replacement: string
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function pathPattern(input: string): RegExp {
+  const parts = input.split(/[\\/]+/).filter(Boolean).map(escapeRegExp)
+  if (parts.length === 0) {
+    return /$^/
+  }
+  const first = parts[0]
+  const body = parts.slice(1).join(sep)
+  const prefix = /^[A-Za-z]:$/.test(first)
+    ? `${first}${body ? sep : ''}`
+    : input.startsWith('/') || input.startsWith('\\')
+      ? sep
+      : ''
+  return new RegExp(`${prefix}${body || (!/^[A-Za-z]:$/.test(first) ? first : '')}`, 'g')
+}
+
+const staticReplacements: Replacement[] = [
   {
     pattern: new RegExp(
       String.raw`C:${sep}Users${sep}${userSegment}${sep}Desktop${sep}${segment}${sep}openclaude-0\.6\.0`,
@@ -34,23 +62,33 @@ const replacements: Array<{ pattern: RegExp; replacement: string }> = [
   },
 ]
 
-export function scrubPublicArtifactText(text: string): string {
-  return replacements.reduce(
+function replacementsFor(options: ScrubOptions): Replacement[] {
+  return [
+    {
+      pattern: pathPattern(options.repoRoot ?? process.cwd()),
+      replacement: '<repo>',
+    },
+    ...staticReplacements,
+  ]
+}
+
+export function scrubPublicArtifactText(text: string, options: ScrubOptions = {}): string {
+  return replacementsFor(options).reduce(
     (current, item) => current.replace(item.pattern, item.replacement),
     text,
   )
 }
 
-export function scrubPublicArtifactValue<T>(value: T): T {
+export function scrubPublicArtifactValue<T>(value: T, options: ScrubOptions = {}): T {
   if (typeof value === 'string') {
-    return scrubPublicArtifactText(value) as T
+    return scrubPublicArtifactText(value, options) as T
   }
   if (Array.isArray(value)) {
-    return value.map((item) => scrubPublicArtifactValue(item)) as T
+    return value.map((item) => scrubPublicArtifactValue(item, options)) as T
   }
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, scrubPublicArtifactValue(item)]),
+      Object.entries(value).map(([key, item]) => [key, scrubPublicArtifactValue(item, options)]),
     ) as T
   }
   return value

--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -170,7 +170,7 @@ describe('public artifact hygiene scanner', () => {
 
   test('write mode scrubs the current repo root before private workspace leak checks', () => {
     const parent = makeTempRepo()
-    const repo = join(parent, '내 순수 재미', 'openclaude-worktrees', 'public-feedback-static-proof')
+    const repo = join(parent, '한글 테스트 경로', 'openclaude-worktrees', 'public-feedback-static-proof')
     const reportDir = join(repo, 'docs', 'product-quality')
     const reportPath = join(reportDir, 'golden-path-terminal-transcripts.md')
     mkdirSync(reportDir, { recursive: true })
@@ -191,7 +191,7 @@ describe('public artifact hygiene scanner', () => {
 
     const sanitized = readFileSync(reportPath, 'utf8')
     expect(sanitized).toContain('<repo>')
-    expect(sanitized).not.toContain('내 순수 재미')
+    expect(sanitized).not.toContain('한글 테스트 경로')
     expect(sanitized).not.toContain(parent)
   })
 

--- a/scripts/public-artifact-hygiene.test.ts
+++ b/scripts/public-artifact-hygiene.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -17,6 +17,14 @@ function makeTempRepo(): string {
 
 function runHygiene(cwd: string) {
   return spawnSync('bun', ['run', scriptPath], {
+    cwd,
+    encoding: 'utf8',
+    shell: false,
+  })
+}
+
+function runHygieneWrite(cwd: string) {
+  return spawnSync('bun', ['run', scriptPath, '--write'], {
     cwd,
     encoding: 'utf8',
     shell: false,
@@ -158,6 +166,33 @@ describe('public artifact hygiene scanner', () => {
     expect(result.status).not.toBe(0)
     expect(`${result.stdout}\n${result.stderr}`).toContain('README.md')
     expect(`${result.stdout}\n${result.stderr}`).toContain('user-workspace-path')
+  })
+
+  test('write mode scrubs the current repo root before private workspace leak checks', () => {
+    const parent = makeTempRepo()
+    const repo = join(parent, '내 순수 재미', 'openclaude-worktrees', 'public-feedback-static-proof')
+    const reportDir = join(repo, 'docs', 'product-quality')
+    const reportPath = join(reportDir, 'golden-path-terminal-transcripts.md')
+    mkdirSync(reportDir, { recursive: true })
+    writeFileSync(
+      reportPath,
+      [
+        `repo_root: ${repo}`,
+        `command: ${join(repo, 'dist', 'cli.mjs')} --version`,
+      ].join('\n'),
+    )
+
+    const writeResult = runHygieneWrite(repo)
+    const output = `${writeResult.stdout}\n${writeResult.stderr}`
+
+    expect(writeResult.status).toBe(0)
+    expect(output).toContain('RESULT: PASS')
+    expect(runHygiene(repo).status).toBe(0)
+
+    const sanitized = readFileSync(reportPath, 'utf8')
+    expect(sanitized).toContain('<repo>')
+    expect(sanitized).not.toContain('내 순수 재미')
+    expect(sanitized).not.toContain(parent)
   })
 
   test('rejects pasted internal runtime context in public docs', () => {

--- a/scripts/public-artifact-hygiene.ts
+++ b/scripts/public-artifact-hygiene.ts
@@ -114,7 +114,31 @@ const userSegment = String.raw`[^\\/"]+`
 const privateWorkspacePlaceholder = '<private' + '-workspace>'
 const privateCodexMemoryPlaceholder = '<private' + '-codex-memory-dir>'
 const privateAgentSkillPlaceholder = '<private' + '-agent-skill-dir>'
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function pathPattern(input: string): RegExp {
+  const parts = input.split(/[\\/]+/).filter(Boolean).map(escapeRegExp)
+  if (parts.length === 0) {
+    return /$^/
+  }
+  const first = parts[0]
+  const body = parts.slice(1).join(sep)
+  const prefix = /^[A-Za-z]:$/.test(first)
+    ? `${first}${body ? sep : ''}`
+    : input.startsWith('/') || input.startsWith('\\')
+      ? sep
+      : ''
+  return new RegExp(`${prefix}${body || (!/^[A-Za-z]:$/.test(first) ? first : '')}`, 'g')
+}
+
 const replacements: Replacement[] = [
+  {
+    pattern: pathPattern(root),
+    replacement: '<repo>',
+  },
   {
     pattern: new RegExp(
       String.raw`C:${sep}Users${sep}${userSegment}${sep}Desktop${sep}${segment}${sep}openclaude-0\.6\.0`,

--- a/src/utils/plugins/zipCache.test.ts
+++ b/src/utils/plugins/zipCache.test.ts
@@ -77,19 +77,19 @@ test('createZipFromDirectory reads file contents from the same opened file it st
             open: 0,
             pathReadFile: 0,
           }
-          const fileStat = {
+          const fileDirent = {
+            name: 'plugin.txt',
             isDirectory: () => false,
             isFile: () => true,
             isSymbolicLink: () => false,
+          }
+          const fileStat = {
+            isFile: () => true,
             mode: 0o100755,
           }
 
           mock.module('fs/promises', () => ({
             ...realFsPromises,
-            lstat: async (path: string) => {
-              if (path === filePath) return fileStat
-              return realFsPromises.lstat(path)
-            },
             open: async (path: string, flags: string) => {
               if (path !== filePath) return realFsPromises.open(path, flags)
               calls.open++
@@ -115,9 +115,12 @@ test('createZipFromDirectory reads file contents from the same opened file it st
               }
               return realFsPromises.readFile(path)
             },
-            readdir: async (path: string) => {
-              if (path === sourceDir) return ['plugin.txt']
-              return realFsPromises.readdir(path)
+            readdir: async (path: string, options?: object) => {
+              if (path === sourceDir) {
+                expect(options).toEqual({ withFileTypes: true })
+                return [fileDirent]
+              }
+              return realFsPromises.readdir(path, options)
             },
             stat: async (path: string, options?: object) => {
               if (path === sourceDir) return { dev: 1n, ino: 2n }

--- a/src/utils/plugins/zipCache.test.ts
+++ b/src/utils/plugins/zipCache.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, expect, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import {
   mkdir,
   mkdtemp,
@@ -8,6 +10,7 @@ import {
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { createZipFromDirectory, extractZipToDirectory } from './zipCache'
 
 const tempDirs: string[] = []
@@ -42,4 +45,118 @@ test('extractZipToDirectory refuses to overwrite an existing extracted file', as
 
   await expect(extractZipToDirectory(zipPath, targetDir)).rejects.toThrow()
   await expect(readFile(targetFile, 'utf8')).resolves.toBe('existing')
+})
+
+test('createZipFromDirectory reads file contents from the same opened file it stats', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-zip-cache-race-'))
+  const testPath = join(tempDir, 'zip-cache-race.test.ts')
+  const zipCacheModuleUrl = pathToFileURL(
+    join(process.cwd(), 'src/utils/plugins/zipCache.ts'),
+  ).href
+  const fflateModuleUrl = pathToFileURL(
+    join(process.cwd(), 'node_modules/fflate/esm/index.mjs'),
+  ).href
+
+  try {
+    writeFileSync(
+      testPath,
+      `
+        import { expect, mock, test } from 'bun:test'
+        import { join } from 'node:path'
+
+        test('isolated ZIP cache race regression', async () => {
+          const realFsPromises = await import('node:fs/promises')
+          const sourceDir = join('virtual-plugin-root', 'source')
+          const filePath = join(sourceDir, 'plugin.txt')
+          const originalText = 'original plugin payload'
+          const replacementText = 'replacement payload from path read'
+          const calls = {
+            close: 0,
+            handleReadFile: 0,
+            handleStat: 0,
+            open: 0,
+            pathReadFile: 0,
+          }
+          const fileStat = {
+            isDirectory: () => false,
+            isFile: () => true,
+            isSymbolicLink: () => false,
+            mode: 0o100755,
+          }
+
+          mock.module('fs/promises', () => ({
+            ...realFsPromises,
+            lstat: async (path: string) => {
+              if (path === filePath) return fileStat
+              return realFsPromises.lstat(path)
+            },
+            open: async (path: string, flags: string) => {
+              if (path !== filePath) return realFsPromises.open(path, flags)
+              calls.open++
+              expect(flags).toBe('r')
+              return {
+                close: async () => {
+                  calls.close++
+                },
+                readFile: async () => {
+                  calls.handleReadFile++
+                  return Buffer.from(originalText)
+                },
+                stat: async () => {
+                  calls.handleStat++
+                  return fileStat
+                },
+              }
+            },
+            readFile: async (path: string) => {
+              if (path === filePath) {
+                calls.pathReadFile++
+                return Buffer.from(replacementText)
+              }
+              return realFsPromises.readFile(path)
+            },
+            readdir: async (path: string) => {
+              if (path === sourceDir) return ['plugin.txt']
+              return realFsPromises.readdir(path)
+            },
+            stat: async (path: string, options?: object) => {
+              if (path === sourceDir) return { dev: 1n, ino: 2n }
+              if (path === filePath) return fileStat
+              return realFsPromises.stat(path, options)
+            },
+          }))
+
+          try {
+            const { createZipFromDirectory } = await import(
+              ${JSON.stringify(zipCacheModuleUrl)} + '?ts=' + Date.now() + '-' + Math.random()
+            )
+            const { unzipSync } = await import(${JSON.stringify(fflateModuleUrl)})
+            const zipData = await createZipFromDirectory(sourceDir)
+            const unzipped = unzipSync(zipData)
+
+            expect(Buffer.from(unzipped['plugin.txt']).toString('utf8')).toBe(originalText)
+            expect(calls.pathReadFile).toBe(0)
+            expect(calls.open).toBe(1)
+            expect(calls.handleStat).toBe(1)
+            expect(calls.handleReadFile).toBe(1)
+            expect(calls.close).toBe(1)
+          } finally {
+            mock.restore()
+          }
+        })
+      `,
+    )
+
+    const result = spawnSync(process.execPath, ['test', testPath], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    })
+
+    if (result.status !== 0) {
+      expect(`${result.stdout}\n${result.stderr}`).toBe('')
+    }
+    expect(result.status).toBe(0)
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
 })

--- a/src/utils/plugins/zipCache.ts
+++ b/src/utils/plugins/zipCache.ts
@@ -30,9 +30,9 @@
  */
 
 import { randomBytes } from 'crypto'
+import type { Dirent } from 'node:fs'
 import {
   chmod,
-  lstat,
   open,
   readdir,
   rename,
@@ -239,9 +239,9 @@ async function collectFilesForZip(
   visited: Set<string>,
 ): Promise<void> {
   const currentDir = relativePath ? join(baseDir, relativePath) : baseDir
-  let entries: string[]
+  let entries: Dirent<string>[]
   try {
-    entries = await readdir(currentDir)
+    entries = await readdir(currentDir, { withFileTypes: true })
   } catch {
     return
   }
@@ -275,37 +275,16 @@ async function collectFilesForZip(
 
   for (const entry of entries) {
     // Skip hidden files that are git-related
-    if (entry === '.git') {
+    if (entry.name === '.git') {
       continue
     }
 
-    const fullPath = join(currentDir, entry)
-    const relPath = relativePath ? `${relativePath}/${entry}` : entry
+    const fullPath = join(currentDir, entry.name)
+    const relPath = relativePath ? `${relativePath}/${entry.name}` : entry.name
 
-    let fileStat
-    try {
-      fileStat = await lstat(fullPath)
-    } catch {
-      continue
-    }
-
-    // Skip symlinked directories (follow symlinked files)
-    if (fileStat.isSymbolicLink()) {
-      try {
-        const targetStat = await stat(fullPath)
-        if (targetStat.isDirectory()) {
-          continue
-        }
-        // Symlinked file — read its contents below
-        fileStat = targetStat
-      } catch {
-        continue // broken symlink
-      }
-    }
-
-    if (fileStat.isDirectory()) {
+    if (entry.isDirectory()) {
       await collectFilesForZip(baseDir, relPath, files, visited)
-    } else if (fileStat.isFile()) {
+    } else if (entry.isFile() || entry.isSymbolicLink()) {
       try {
         const fd = await open(fullPath, 'r')
         try {

--- a/src/utils/plugins/zipCache.ts
+++ b/src/utils/plugins/zipCache.ts
@@ -33,8 +33,8 @@ import { randomBytes } from 'crypto'
 import {
   chmod,
   lstat,
+  open,
   readdir,
-  readFile,
   rename,
   rm,
   stat,
@@ -307,14 +307,23 @@ async function collectFilesForZip(
       await collectFilesForZip(baseDir, relPath, files, visited)
     } else if (fileStat.isFile()) {
       try {
-        const content = await readFile(fullPath)
-        // os=3 (Unix) + st_mode in high 16 bits of external_attr — this is
-        // what parseZipModes reads back on extraction. fileStat is already
-        // in hand from the lstat/stat above, so no extra syscall.
-        files[relPath] = [
-          new Uint8Array(content),
-          { os: 3, attrs: (fileStat.mode & 0xffff) << 16 },
-        ]
+        const fd = await open(fullPath, 'r')
+        try {
+          const openedStat = await fd.stat()
+          if (!openedStat.isFile()) {
+            continue
+          }
+          const content = await fd.readFile()
+          // os=3 (Unix) + st_mode in high 16 bits of external_attr — this is
+          // what parseZipModes reads back on extraction. Use the opened file's
+          // stat so content and mode come from the same descriptor.
+          files[relPath] = [
+            new Uint8Array(content),
+            { os: 3, attrs: (openedStat.mode & 0xffff) << 16 },
+          ]
+        } finally {
+          await fd.close()
+        }
       } catch (error) {
         logForDebugging(`Failed to read file for zip: ${relPath}: ${error}`)
       }


### PR DESCRIPTION
## Summary
- Harden plugin ZIP creation so file contents and mode are read from the same opened file descriptor before writing cache entries.
- Teach generated public-report sanitization to scrub the current repo root before broader user-home fallbacks, including worktree paths with private/local workspace names.
- Extend public artifact hygiene write mode with the same current-root scrub so accidental local-path report output can be repaired before check mode.

## Verification
- `bun test src\utils\plugins\zipCache.test.ts scripts\product-report-sanitizer.test.ts scripts\public-artifact-hygiene.test.ts scripts\public-repo-readiness.test.ts`
- `bun run typecheck --pretty false`
- `git diff --check`
- `bun run product:quality`
- `bun run verify:privacy`

## Boundaries
- `product:quality` passed locally and still records local/protected environment boundaries without turning them into readiness claims.
- Generated product-quality report churn from the local run is intentionally not included in this PR.