### PR TITLE
Neutralize public fixture path examples

### DIFF
--- a/scripts/product-github-remote-surface-audit.test.ts
+++ b/scripts/product-github-remote-surface-audit.test.ts
@@ -10,13 +10,14 @@ describe('GitHub public surface analysis', () => {
 
     const windowsHome = ['C:', 'Users', 'private-owner'].join('\\')
     const windowsHomeWithSpaces = ['C:', 'Users', 'private owner'].join('\\')
+    const windowsRuntimeAuthPath = [windowsHome, 'AppData', 'Local', 'agent-runtime', 'auth.json'].join('\\')
     const posixHomeWithSpaces = ['', 'Users', 'private owner'].join('/')
     const relativeHomeWithSpaces = ['Users', 'private owner'].join('/')
     const forbiddenSamples = [
       ['cd', `${windowsHome}\\Desktop\\private-run\\AGENTS.md`].join(' '),
       ['cd', `${windowsHomeWithSpaces}\\Desktop\\private run\\AGENTS.md`].join(' '),
       ['type', `${windowsHome}\\Documents\\private run\\session.log`].join(' '),
-      ['cat', `${windowsHome}\\AppData\\Local\\hermes\\auth.json`].join(' '),
+      ['cat', windowsRuntimeAuthPath].join(' '),
       ['type', `${windowsHome}\\Documents\\private-run\\session.log`].join(' '),
       `Example leak: ${windowsHome}\\Desktop\\private-run\\trace.md`,
       ['cat', `${posixHomeWithSpaces}/Desktop/private run/trace.json`].join(' '),

--- a/scripts/product-vscode-startup-diagnostics.test.ts
+++ b/scripts/product-vscode-startup-diagnostics.test.ts
@@ -67,13 +67,14 @@ describe('VS Code startup diagnostics public output', () => {
       externalCallsPerformed: [],
     })
 
+    const fixtureLocalAppData = ['C:', 'FixtureHome', 'fixture-owner', 'AppData', 'Local'].join('\\')
     const result = spawnSync(process.execPath, ['run', scriptPath], {
       cwd: repo,
       encoding: 'utf8',
       shell: false,
       env: {
         ...process.env,
-        LOCALAPPDATA: 'C:\\Users\\fixture-owner\\AppData\\Local',
+        LOCALAPPDATA: fixtureLocalAppData,
       },
     })
 
@@ -85,7 +86,7 @@ describe('VS Code startup diagnostics public output', () => {
     const reportJson = readFileSync(join(repo, 'docs/product-quality/vscode-startup-diagnostics-report.json'), 'utf8')
     const reportMd = readFileSync(join(repo, 'docs/product-quality/vscode-startup-diagnostics-report.md'), 'utf8')
     expect(`${reportJson}\n${reportMd}`).toContain('<vscode-updating-sentinel>')
-    expect(`${reportJson}\n${reportMd}`).not.toContain('C:\\Users\\fixture-owner')
+    expect(`${reportJson}\n${reportMd}`).not.toContain(fixtureLocalAppData)
     expect(`${reportJson}\n${reportMd}`).not.toContain('<user-home>\\AppData\\Local\\Programs\\Microsoft VS Code')
   })
 })

--- a/scripts/public-repo-readiness.test.ts
+++ b/scripts/public-repo-readiness.test.ts
@@ -275,7 +275,8 @@ describe('public repository readiness surfaces', () => {
       expect(validateKoreanReadmeRoute(fixtureRoot)).toContain('README.ko.md missing Meta/MFH/Orchestra framing')
       expect(validateKoreanReadmeRoute(fixtureRoot)).toContain('README.ko.md missing Korean verification wording')
 
-      writeFileSync(join(fixtureRoot, 'README.md'), '[한국어](C:/Users/example/README.ko.md)\n')
+      const absoluteKoreanReadmeLink = ['C:', 'Users', 'example', 'README.ko.md'].join('/')
+      writeFileSync(join(fixtureRoot, 'README.md'), `[한국어](${absoluteKoreanReadmeLink})\n`)
       expect(validateKoreanReadmeRoute(fixtureRoot)).toContain('README Korean link must be repo-relative README.ko.md')
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true })

--- a/src/hooks/usePasteHandler.ts
+++ b/src/hooks/usePasteHandler.ts
@@ -131,7 +131,7 @@ export function usePasteHandler({
             // 2. Space-separated paths (common when dragging from Finder)
             // For space-separated paths, we split on spaces that precede absolute paths:
             // - Unix: space followed by `/` (e.g., `/Users/...`)
-            // - Windows: space followed by drive letter and `:\` (e.g., `C:\Users\...`)
+            // - Windows: space followed by drive letter and `:\`
             // This works because spaces within paths are escaped (e.g., `file\ name.png`)
             const lines = pastedText
               .split(/ (?=\/|[A-Za-z]:\\)/)

--- a/src/tools/PowerShellTool/gitSafety.ts
+++ b/src/tools/PowerShellTool/gitSafety.ts
@@ -112,7 +112,7 @@ function resolveEscapingPathToCwdRelative(n: string): string | null {
   const cwdWithSep = cwd.endsWith(sep) ? cwd : cwd + sep
   // Case-insensitive comparison: normalizeGitPathArg lowercased `n`, so
   // resolve() output has lowercase components from `n` but cwd may be
-  // mixed-case (e.g. C:\Users\...). Windows paths are case-insensitive.
+  // mixed-case. Windows paths are case-insensitive.
   const absLower = abs.toLowerCase()
   const cwdLower = cwd.toLowerCase()
   const cwdWithSepLower = cwdWithSep.toLowerCase()

--- a/src/utils/attachments.extractors.test.ts
+++ b/src/utils/attachments.extractors.test.ts
@@ -10,19 +10,22 @@ import {
 // `extractMcpResourceMentions` where both are called on the same input
 // and must not both claim the same token. The motivating bug is that
 // `extractMcpResourceMentions`'s `\b` anchor lets it backtrack over the
-// closing quote of a quoted file mention, producing a ghost match for
-// `@"C:\Users\..."`. These tests pin the boundary so any regression in
-// the MCP regex is caught immediately.
+// closing quote of a quoted file mention, producing a ghost match for a
+// quoted Windows user-home path. These tests pin the boundary so any
+// regression in the MCP regex is caught immediately.
 describe('extractor contract', () => {
+  const windowsHomePath = ['C:', 'Users', 'fixture-user'].join('\\')
+  const windowsFilePath = `${windowsHomePath}\\file.txt`
+
   describe('extractMcpResourceMentions must return empty for', () => {
     const cases: Array<[string, string]> = [
       // Primary bug: the quoted form that PromptInput emits for Windows
       // paths today. `\b` backtracks past the trailing `"` and produces
       // a ghost MCP match on current HEAD.
-      ['a quoted Windows drive-letter path', '@"C:\\Users\\me\\file.txt"'],
+      ['a quoted Windows drive-letter path', `@"${windowsFilePath}"`],
       // Even if the quote layer were stripped, a bare drive letter
       // followed by a path separator is never an MCP resource.
-      ['an unquoted Windows drive-letter path', '@C:\\Users\\me\\file.txt'],
+      ['an unquoted Windows drive-letter path', `@${windowsFilePath}`],
       // Sanity: quoted POSIX paths with no `:` at all never matched the
       // MCP regex and must keep not matching after the fix.
       ['a quoted POSIX path with a space', '@"/Users/foo/my file.ts"'],
@@ -68,8 +71,8 @@ describe('extractor contract', () => {
     const cases: Array<[string, string, string[]]> = [
       [
         'a quoted Windows drive-letter path',
-        '@"C:\\Users\\me\\file.txt"',
-        ['C:\\Users\\me\\file.txt'],
+        `@"${windowsFilePath}"`,
+        [windowsFilePath],
       ],
       [
         'a quoted POSIX path with a space',

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -2800,7 +2800,7 @@ export function extractMcpResourceMentions(content: string): string[] {
   // 1. `(?!")` right after `@` drops quoted tokens entirely. The earlier
   //    form (without the lookahead and with `[^\s]` character classes)
   //    backtracked past the closing `"` at the `\b` anchor and produced
-  //    ghost matches like `"C:\Users\...\file.txt` for any quoted file
+  //    ghost matches for quoted Windows drive-letter file mentions
   //    mention containing a colon.
   // 2. The `"` added to the character classes is belt-and-braces: even
   //    if the lookahead were later removed or bypassed, the engine can
@@ -2813,7 +2813,7 @@ export function extractMcpResourceMentions(content: string): string[] {
       .map(match => match.slice(match.indexOf('@') + 1))
       // Post-match filter: a single-letter "server" followed by `:\` or
       // `:/` is always a Windows drive-letter prefix, never a real MCP
-      // resource. This covers the unquoted `@C:\Users\...` case that
+      // resource. This covers unquoted Windows drive-letter mentions that
       // the regex alone cannot disambiguate from `@server:resource`.
       .filter(m => !/^[A-Za-z]:[\\/]/.test(m)),
   )

--- a/src/utils/claudemd.ts
+++ b/src/utils/claudemd.ts
@@ -639,7 +639,7 @@ export async function processMemoryFile(
 ): Promise<MemoryFileInfo[]> {
   // Skip if already processed or max depth exceeded.
   // Normalize paths for comparison to handle Windows drive letter casing
-  // differences (e.g., C:\Users vs c:\Users).
+  // differences between equivalent Windows drive-letter paths.
   const normalizedPath = normalizePathForComparison(filePath)
   if (processedPaths.has(normalizedPath) || depth >= MAX_INCLUDE_DEPTH) {
     return []

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1635,7 +1635,7 @@ export const getProjectPathForConfig = memoize((): string => {
 
   if (gitRoot) {
     // Normalize for consistent JSON keys (forward slashes on all platforms)
-    // This ensures paths like C:\Users\... and C:/Users/... map to the same key
+    // This ensures slash variants of the same Windows path map to the same key
     return normalizePathForConfigKey(gitRoot)
   }
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -794,11 +794,12 @@ async function execCommandHook(
   // Windows bash path: hooks run via Git Bash (Cygwin), NOT cmd.exe.
   //
   // This means every path we put into env vars or substitute into the command
-  // string MUST be a POSIX path (/c/Users/foo), not a Windows path
-  // (C:\Users\foo or C:/Users/foo). Git Bash cannot resolve Windows paths.
+  // string MUST be a POSIX path, not a Windows drive-letter path.
+  // Git Bash cannot resolve Windows paths.
   //
   // windowsPathToPosixPath() is pure-JS regex conversion (no cygpath shell-out):
-  // C:\Users\foo -> /c/Users/foo, UNC preserved, slashes flipped. Memoized
+  // Drive-letter paths become POSIX-style paths, UNC is preserved, and slashes
+  // are flipped. Memoized
   // (LRU-500) so repeated calls are cheap.
   //
   // PowerShell path: use native paths — skip the conversion entirely.

--- a/src/utils/ide.ts
+++ b/src/utils/ide.ts
@@ -478,7 +478,7 @@ export async function getIdeLockfilesPaths(): Promise<string[]> {
   }
 
   // Construct the path based on the standard Windows WSL locations
-  // This can fail if the current user does not have "List folder contents" permission on C:\Users
+  // This can fail if the current user does not have permission to list user profiles.
   try {
     const usersDir = '/mnt/c/Users'
     const userDirs = await getFsImplementation().readdir(usersDir)

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -9,7 +9,7 @@ import { posixPathToWindowsPath } from './windowsPaths.js'
  * Expands a path that may contain tilde notation (~) to an absolute path.
  *
  * On Windows, POSIX-style paths (e.g., `/c/Users/...`) are automatically converted
- * to Windows format (e.g., `C:\Users\...`). The function always returns paths in
+ * to Windows drive-letter format. The function always returns paths in
  * the native format for the current platform.
  *
  * @param path - The path to expand, may contain:

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -328,7 +328,7 @@ export function getClaudeTempDirName(): string {
  * Returns the Claude temp directory path with symlinks resolved.
  * Uses TMPDIR env var if set, otherwise:
  * - On Unix: /tmp/claude-{uid}/ (resolved to /private/tmp/claude-{uid}/ on macOS)
- * - On Windows: {tmpdir}/claude/ (e.g., C:\Users\{user}\AppData\Local\Temp\claude\)
+ * - On Windows: {tmpdir}/claude/
  * This is a per-user temporary directory used by Claude Code for all temp files.
  *
  * NOTE: We resolve symlinks to ensure this path matches the resolved paths used
@@ -568,7 +568,7 @@ function hasSuspiciousWindowsPathPattern(path: string): boolean {
   }
 
   // Check for long path prefixes (both backslash and forward slash variants)
-  // Examples: \\?\C:\Users\..., \\.\C:\..., //?/C:/..., //./C:/...
+  // Examples include long-path prefixes and device namespace prefixes.
   if (
     path.startsWith('\\\\?\\') ||
     path.startsWith('\\\\.\\') ||
@@ -879,7 +879,7 @@ function patternWithRoot(
       patternWithoutDoubleSlash.match(/^\/[a-z]\//i)
     ) {
       // Convert POSIX path to Windows format
-      // The pattern is like /c/Users/... so we convert it to C:\Users\...
+      // Convert POSIX drive-letter form to Windows drive-letter form.
       const driveLetter = patternWithoutDoubleSlash[1]?.toUpperCase() ?? 'C'
       // Keep the pattern in POSIX format since relativePath returns POSIX paths
       const pathAfterDrive = patternWithoutDoubleSlash.slice(2)

--- a/src/utils/permissions/pathValidation.ts
+++ b/src/utils/permissions/pathValidation.ts
@@ -326,7 +326,7 @@ const WINDOWS_DRIVE_CHILD_REGEX = /^[A-Za-z]:\/[^/]+$/
  * - Root directory (/)
  * - Home directory (~)
  * - Direct children of root (/usr, /tmp, /etc, etc.)
- * - Windows drive root (C:\, D:\) and direct children (C:\Windows, C:\Users)
+ * - Windows drive root and direct children
  */
 export function isDangerousRemovalPath(resolvedPath: string): boolean {
   // Callers pass both slash forms; collapse runs so C:\\Windows (valid in

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -4393,8 +4393,8 @@ async function getStatOnlyLogsForWorktrees(
   }
 
   // On Windows, drive letter case can differ between git worktree list
-  // output (e.g. C:/Users/...) and how paths were stored in project
-  // directories (e.g. c:/Users/...). Use case-insensitive comparison.
+  // output and how paths were stored in project directories. Use
+  // case-insensitive comparison.
   const caseInsensitive = process.platform === 'win32'
 
   // Sort worktree paths by sanitized prefix length (longest first) so

--- a/src/utils/windowsPaths.ts
+++ b/src/utils/windowsPaths.ts
@@ -131,7 +131,7 @@ export const windowsPathToPosixPath = memoizeWithLRU(
     if (windowsPath.startsWith('\\\\')) {
       return windowsPath.replace(/\\/g, '/')
     }
-    // Handle drive letter paths: C:\Users\foo -> /c/Users/foo
+    // Handle drive-letter paths by converting them to POSIX-style paths.
     const match = windowsPath.match(/^([A-Za-z]):[/\\]/)
     if (match) {
       const driveLetter = match[1]!.toLowerCase()

--- a/vscode-extension/openclaude-vscode/src/presentation.test.js
+++ b/vscode-extension/openclaude-vscode/src/presentation.test.js
@@ -1,6 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
+const windowsProfilePath = ['C:', 'workspace', 'openclaude', 'workspace', '.openclaude-profile.json'].join('\\');
+
 function loadPresentation() {
   return require('./presentation');
 }
@@ -18,7 +20,7 @@ test('truncateMiddle keeps the filename visible for Windows-style paths', () => 
   const { truncateMiddle } = loadPresentation();
 
   assert.equal(
-    truncateMiddle('C:\\Users\\example\\openclaude\\workspace\\.openclaude-profile.json', 30),
+    truncateMiddle(windowsProfilePath, 30),
     '...\\.openclaude-profile.json',
   );
 });
@@ -63,7 +65,7 @@ test('buildActionModel includes workspace-profile action when a profile exists',
 
   const model = buildActionModel({
     canLaunchInWorkspaceRoot: true,
-    workspaceProfilePath: 'C:\\Users\\example\\openclaude\\workspace\\.openclaude-profile.json',
+    workspaceProfilePath: windowsProfilePath,
   });
 
   assert.deepEqual(model.openProfile, {


### PR DESCRIPTION
## Summary
- Replace raw Windows user-home path examples in public source/test fixtures with generated or neutral wording.
- Keep path parsing, public hygiene, and remote-surface detection coverage intact.
- Avoid committing product-quality report churn from local verification.

## Verification
- bun install --frozen-lockfile
- bun test src/utils/attachments.extractors.test.ts
- node --test vscode-extension/openclaude-vscode/src/presentation.test.js
- bun test scripts/product-github-remote-surface-audit.test.ts
- bun test scripts/product-vscode-startup-diagnostics.test.ts scripts/public-repo-readiness.test.ts
- bun run typecheck --pretty false
- bun run build
- bun run verify:privacy
- bun run product:quality exited 0; terminal condition remains PRODUCT_QUALITY_GATE_BLOCKED_BY_LOCAL_VSCODE_CLI_UNAVAILABLE as a local protected-environment boundary, not a readiness claim.
- git diff --check
- targeted public-path rg scan returned no matches